### PR TITLE
Fixed verbose option definition so yargs doesn't break when parsing argv

### DIFF
--- a/bin/taskcluster-run.js
+++ b/bin/taskcluster-run.js
@@ -14,9 +14,10 @@ var yargs = require('yargs')
   .describe('env-file', 'Environment variable file to apply on worker')
   .describe('provisioner-id', 'Provisioner ID. Example: aws-provisioner')
   .describe('worker-type', 'Worker Type. Example: \'cli\'')
-  .describe('verbose', {
-    type: 'boolean',
+  .options('verbose', {
+    boolean: true,
     default: true,
+    describe: 'Log additional details'
   })
   .options('owner', {
     default: process.env.TASKCLUSTER_TASK_OWNER || process.env.EMAIL,


### PR DESCRIPTION
The way 'verbose' was defined was causing issues when yargs went to parse the arguments.  Switching it to be an option instead fixes the issue and matches what run-task does for this option.
