### PR TITLE
Added version command

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/taskcluster/taskcluster-cli/client"
 	"github.com/taskcluster/taskcluster-cli/config"
 	"github.com/taskcluster/taskcluster-cli/extpoints"
+	"github.com/taskcluster/taskcluster-cli/version"
 )
 
 func pad(s string, length int) string {
@@ -64,21 +65,14 @@ func main() {
 	usage += "\n"
 
 	// Parse arguments
-	arguments, _ := docopt.Parse(usage, nil, true, "TaskCluster version 1.0", true)
+	arguments, _ := docopt.Parse(usage, nil, true, version.VersionNumber, true)
 	cmd := arguments["<command>"].(string)
 	args := arguments["<args>"].([]string)
 
 	// Special case for handling "taskcluster help" ensuring it's the same as
-	// "taskcluster --help".
+	// "taskcluster --help". This should be the only special case necessary!
 	if cmd == "help" && len(args) == 0 {
 		fmt.Print(usage)
-		return
-	}
-
-	// Special case for handling "taskcluster version" ensuring it's the same as
-	// "taskcluster --version".
-	if cmd == "version" && len(args) == 0 {
-		fmt.Println("TaskCluster version 1.0")
 		return
 	}
 
@@ -94,7 +88,7 @@ func main() {
 	// Parse args for command provider
 	subArguments, _ := docopt.Parse(
 		provider.Usage(), append([]string{cmd}, args...),
-		true, "TaskCluster version 1.0", false,
+		true, version.VersionNumber, false,
 	)
 
 	// Create credentials, if available in configuration

--- a/main.go
+++ b/main.go
@@ -64,14 +64,21 @@ func main() {
 	usage += "\n"
 
 	// Parse arguments
-	arguments, _ := docopt.Parse(usage, nil, true, "taskcluster", true)
+	arguments, _ := docopt.Parse(usage, nil, true, "TaskCluster version 1.0", true)
 	cmd := arguments["<command>"].(string)
 	args := arguments["<args>"].([]string)
 
 	// Special case for handling "taskcluster help" ensuring it's the same as
-	// "taskcluster --help". This should be the only special case necessary!
+	// "taskcluster --help".
 	if cmd == "help" && len(args) == 0 {
 		fmt.Print(usage)
+		return
+	}
+
+	// Special case for handling "taskcluster version" ensuring it's the same as
+	// "taskcluster --version".
+	if cmd == "version" && len(args) == 0 {
+		fmt.Println("TaskCluster version 1.0")
 		return
 	}
 
@@ -87,7 +94,7 @@ func main() {
 	// Parse args for command provider
 	subArguments, _ := docopt.Parse(
 		provider.Usage(), append([]string{cmd}, args...),
-		true, "taskcluster", false,
+		true, "TaskCluster version 1.0", false,
 	)
 
 	// Create credentials, if available in configuration

--- a/version.go
+++ b/version.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/taskcluster/taskcluster-cli/extpoints"
+)
+
+func init() {
+	extpoints.Register("version", version{})
+}
+
+type version struct{}
+
+func (version) ConfigOptions() map[string]extpoints.ConfigOption {
+	return nil
+}
+
+func (version) Summary() string {
+	return "Prints the TaskCluster version."
+}
+
+func (version) Usage() string {
+	usage := "Prints the TaskCluster version\n"
+	usage += "\n"
+	usage += "Usage:\n"
+	usage += "  taskcluster version\n"
+	return usage
+}
+
+func (version) Execute(context extpoints.Context) bool {
+	command := context.Arguments["<command>"].(string)
+	provider := extpoints.CommandProviders()[command]
+	if provider == nil {
+		fmt.Println("Unknown command: ", command)
+		return false
+	}
+	fmt.Print(provider.Usage())
+	return true
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,10 +1,12 @@
-package main
+package version
 
 import (
 	"fmt"
 
 	"github.com/taskcluster/taskcluster-cli/extpoints"
 )
+
+var VersionNumber = fmt.Sprintf("taskcluster (TaskCluster CLI) version %d.%d.%d", 1, 0, 0)
 
 func init() {
 	extpoints.Register("version", version{})
@@ -20,21 +22,23 @@ func (version) Summary() string {
 	return "Prints the TaskCluster version."
 }
 
+func usage() string {
+	return `Usage:
+  taskcluster VERSION
+`
+}
+
 func (version) Usage() string {
-	usage := "Prints the TaskCluster version\n"
-	usage += "\n"
-	usage += "Usage:\n"
-	usage += "  taskcluster version\n"
-	return usage
+	return usage()
 }
 
 func (version) Execute(context extpoints.Context) bool {
-	command := context.Arguments["<command>"].(string)
+	command := context.Arguments["VERSION"].(string)
 	provider := extpoints.CommandProviders()[command]
 	if provider == nil {
-		fmt.Println("Unknown command: ", command)
+		panic(fmt.Sprintf("Unknown command: %s", command))
 		return false
 	}
-	fmt.Print(provider.Usage())
+	fmt.Println(VersionNumber)
 	return true
 }


### PR DESCRIPTION
This adds the `taskcluster version` command. Additionally, the `taskcluster --version` command can be used to display the version.

Currently, a fake version is printed. This can be changed later.

A new `version.go` file is added. The version is specified in `docopt.Parse()` as per the [documentation](https://godoc.org/github.com/docopt/docopt.go#Parse). 

This PR fixes issue(#19).

/cc @walac for review.