### PR TITLE
Added s3 command

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1,0 +1,233 @@
+package s3
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awsS3 "github.com/aws/aws-sdk-go/service/s3"
+	awsS3Manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/taskcluster/taskcluster-cli/config"
+	"github.com/taskcluster/taskcluster-cli/extpoints"
+	"github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/auth"
+)
+
+func init() {
+	extpoints.Register("s3", S3{})
+}
+
+type S3 struct{}
+
+func (S3) ConfigOptions() map[string]extpoints.ConfigOption {
+	return nil
+}
+
+func (S3) Summary() string {
+	return "Uploads/downloads file to/from AWS S3."
+}
+
+func usage() string {
+	return `Upload/Download file to/from AWS S3.
+Usage:
+  taskcluster S3 upload <file> <region> <level> <bucket> <prefix>
+  taskcluster S3 download <key> <region> <level> <bucket> <prefix>
+  taskcluster S3 help <subcommand>
+`
+}
+
+func (S3) Usage() string {
+	return usage()
+}
+
+func (S3) Execute(context extpoints.Context) bool {
+	argv := context.Arguments
+
+	// Check for command
+	command := argv["S3"].(string)
+	provider := extpoints.CommandProviders()[command]
+	if provider == nil {
+		panic(fmt.Sprintf("Unknown command: %s", command))
+	}
+
+	// Print help for subcommands
+	if argv["help"] == true {
+
+		subcommand, ok := argv["<subcommand>"].(string)
+		if !ok {
+			panic(fmt.Sprintf("Unknown subcommand: %s", subcommand))
+		}
+
+		if subcommand == "upload" {
+			fmt.Println(`Usage:
+  taskcluster S3 upload <file> <region> <level> <bucket> <prefix>`)
+		} else if subcommand == "download" {
+			fmt.Println(`Usage:
+  taskcluster S3 download <key> <region> <level> <bucket> <prefix>`)
+		}
+		return true
+	}
+
+	// Parse for bucket, prefix, level and region
+	bucket, ok := argv["<bucket>"].(string)
+	if !ok {
+		fmt.Println("Invalid bucket format.")
+		return false
+	}
+	prefix, ok := argv["<prefix>"].(string)
+	if !ok {
+		fmt.Println("Invalid prefix format.")
+		return false
+	}
+	level, ok := argv["<level>"].(string)
+	if !ok {
+		fmt.Println("Invalid level format.")
+		return false
+	}
+	region, ok := argv["<region>"].(string)
+	if !ok {
+		fmt.Println("Invalid region format.")
+		return false
+	}
+
+	// Load configuration
+	config, err := config.Load()
+	if err != nil {
+		fmt.Println("Failed to load configuration file, error: ", err)
+		return false
+	}
+
+	// Set credentials for auth
+	myAuth := auth.New(
+		&tcclient.Credentials{
+			ClientID:    config["config"]["clientId"].(string),
+			AccessToken: config["config"]["accessToken"].(string),
+			Certificate: config["config"]["certificate"].(string),
+		},
+	)
+
+	// Get credential for AWS S3
+	resp, err := myAuth.AwsS3Credentials(level, bucket, prefix)
+	if err != nil {
+		fmt.Println("Failed to load AWS S3 credentials: ", err)
+		return false
+	}
+
+	// Set Credentials for AWS S3
+	aws_access_key_id := resp.Credentials.AccessKeyID
+	aws_secret_access_key := resp.Credentials.SecretAccessKey
+	aws_session_token := resp.Credentials.SessionToken
+	//aws_expires := &resp.Expires
+
+	creds := credentials.NewStaticCredentials(aws_access_key_id, aws_secret_access_key, aws_session_token)
+	_, err = creds.Get()
+	if err != nil {
+		fmt.Printf("Invalid credentials: %s", err)
+		return false
+	}
+
+	// Create a session which contains the configurations for the SDK.
+	// Use the session to create the service clients to make API calls to AWS.
+	aws_config := aws.NewConfig().WithRegion(region).WithCredentials(creds)
+	sess := session.New(aws_config)
+
+	// For upload
+	if argv["upload"] == true {
+
+		// Parse for filename
+		filename, ok := argv["<file>"].(string)
+		if !ok {
+			fmt.Println("Invalid file format.")
+			return false
+		}
+
+		// Create service client
+		svc := awsS3Manager.NewUploader(sess)
+
+		// Open the filename and return the file
+		file, err := os.Open(filename)
+		if err != nil {
+			fmt.Println("Failed to open file", filename, err)
+			return false
+		}
+		defer file.Close()
+
+		// Generate key from filename
+		key := filepath.Base(filename)
+
+		fmt.Printf("Uploading %s to s3://%s/%s...\n", key, bucket, prefix)
+
+		// Upload the file
+		params := &awsS3Manager.UploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+			Body:   file,
+			//Expires: aws_expires,
+		}
+		_, err = svc.Upload(params)
+		if err != nil {
+			if multierr, ok := err.(awsS3Manager.MultiUploadFailure); ok {
+				// Process error and its associated uploadID for Multipart Upload failure
+				fmt.Println("Multipart Upload error: ", multierr.Code(), multierr.Message(), multierr.UploadID())
+				return false
+			} else {
+				// Process error generically
+				fmt.Printf("Failed to upload %s to s3://%s/%s, %s\n", key, bucket, prefix, err.Error())
+				return false
+			}
+		}
+
+		fmt.Printf("Successfully uploaded %s to s3://%s/%s\n", key, bucket, prefix)
+
+	} else if argv["download"] == true {
+
+		// Parse for key
+		key, ok := argv["<key>"].(string)
+		if !ok {
+			fmt.Println("Invalid key format.")
+			return false
+		}
+
+		// Create service client
+		svc := awsS3Manager.NewDownloader(sess)
+
+		// Get current path
+		pwd, err := os.Getwd()
+		if err != nil {
+			fmt.Println("Error occured: ", err)
+			return false
+		}
+
+		// Create filepath
+		filename := filepath.Join(pwd, key)
+		if err := os.MkdirAll(filepath.Dir(filename), 0775); err != nil {
+			fmt.Println("Unable to create directory: ", err)
+			return false
+		}
+
+		// Setup the local file
+		file, err := os.Create(filename)
+		if err != nil {
+			panic(err)
+		}
+		defer file.Close()
+
+		fmt.Printf("Downloading from s3://%s/%s to %s...\n", bucket, key, filename)
+
+		// Download the file
+		params := &awsS3.GetObjectInput{Bucket: &bucket, Key: &key}
+		_, err = svc.Download(file, params)
+		if err != nil {
+			fmt.Printf("Failed to download data to %s from s3://%s/%s\n", filename, bucket, key)
+			return false
+		}
+
+		fmt.Printf("Successfully downloaded to %s from s3://%s/%s\n", filename, bucket, key)
+	} else {
+		panic(fmt.Sprintf("Unknown command: %s", command))
+	}
+	return true
+}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -16,6 +16,7 @@ import (
 
 // Initial setup
 var s3Test S3
+var context extpoints.Context
 
 func createFile() string {
 	// Get current path
@@ -40,8 +41,26 @@ func createFile() string {
 	return filename
 }
 
+func loadConfig() {
+	// Load configuration
+	config, err := config.Load()
+	if err != nil {
+		fmt.Println("Failed to load configuration file, error: ", err)
+	}
+
+	// Set context
+	context = extpoints.Context{}
+	context.Config = nil
+	context.Credentials = &client.Credentials{
+		ClientID:    config["config"]["clientId"].(string),
+		AccessToken: config["config"]["accessToken"].(string),
+		Certificate: config["config"]["certificate"].(string),
+	}
+}
+
 func TestPutFolder1Folder2(t *testing.T) {
 	filename := createFile()
+	loadConfig()
 
 	// Parse arguments
 	os.Args = []string{"taskcluster", "s3", "put", filename, "test-bucket-for-any-garbage", "folder1/folder2/"}
@@ -50,22 +69,7 @@ func TestPutFolder1Folder2(t *testing.T) {
 		fmt.Println("Failed to parse arguments")
 	}
 
-	// Load configuration
-	config, err := config.Load()
-	if err != nil {
-		fmt.Println("Failed to load configuration file, error: ", err)
-	}
-
-	// Set context
-	var context extpoints.Context
 	context.Arguments = arguments
-	context.Config = nil
-	context.Credentials = &client.Credentials{
-		ClientID:    config["config"]["clientId"].(string),
-		AccessToken: config["config"]["accessToken"].(string),
-		Certificate: config["config"]["certificate"].(string),
-	}
-
 	result := s3Test.Execute(context)
 
 	assert.Equal(t, true, result, "An error occured during execution.")
@@ -79,6 +83,8 @@ func TestGetWithTarget(t *testing.T) {
 	}
 	target := filepath.Join(pwd, "testFile.txt")
 
+	loadConfig()
+
 	// Parse arguments
 	os.Args = []string{"taskcluster", "s3", "get", "test-bucket-for-any-garbage", "folder1/folder2/testFile.txt", target}
 	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
@@ -86,27 +92,15 @@ func TestGetWithTarget(t *testing.T) {
 		fmt.Println("Failed to parse arguments")
 	}
 
-	// Load configuration
-	config, err := config.Load()
-	if err != nil {
-		fmt.Println("Failed to load configuration file, error: ", err)
-	}
-
-	// Set context
-	var context extpoints.Context
 	context.Arguments = arguments
-	context.Config = nil
-	context.Credentials = &client.Credentials{
-		ClientID:    config["config"]["clientId"].(string),
-		AccessToken: config["config"]["accessToken"].(string),
-		Certificate: config["config"]["certificate"].(string),
-	}
-
 	result := s3Test.Execute(context)
+
 	assert.Equal(t, true, result, "An error occured during execution.")
 }
 
 func TestGetWithOutTarget(t *testing.T) {
+	loadConfig()
+
 	// Parse arguments
 	os.Args = []string{"taskcluster", "s3", "get", "test-bucket-for-any-garbage", "folder1/folder2/testFile.txt"}
 	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
@@ -114,27 +108,15 @@ func TestGetWithOutTarget(t *testing.T) {
 		fmt.Println("Failed to parse arguments")
 	}
 
-	// Load configuration
-	config, err := config.Load()
-	if err != nil {
-		fmt.Println("Failed to load configuration file, error: ", err)
-	}
-
-	// Set context
-	var context extpoints.Context
 	context.Arguments = arguments
-	context.Config = nil
-	context.Credentials = &client.Credentials{
-		ClientID:    config["config"]["clientId"].(string),
-		AccessToken: config["config"]["accessToken"].(string),
-		Certificate: config["config"]["certificate"].(string),
-	}
-
 	result := s3Test.Execute(context)
+
 	assert.Equal(t, true, result, "An error occured during execution.")
 }
 
 func TestGetFolder1(t *testing.T) {
+	loadConfig()
+
 	// Parse arguments
 	os.Args = []string{"taskcluster", "s3", "get", "test-bucket-for-any-garbage", "folder1/testFile.txt"}
 	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
@@ -142,28 +124,15 @@ func TestGetFolder1(t *testing.T) {
 		fmt.Println("Failed to parse arguments")
 	}
 
-	// Load configuration
-	config, err := config.Load()
-	if err != nil {
-		fmt.Println("Failed to load configuration file, error: ", err)
-	}
-
-	// Set context
-	var context extpoints.Context
 	context.Arguments = arguments
-	context.Config = nil
-	context.Credentials = &client.Credentials{
-		ClientID:    config["config"]["clientId"].(string),
-		AccessToken: config["config"]["accessToken"].(string),
-		Certificate: config["config"]["certificate"].(string),
-	}
-
 	result := s3Test.Execute(context)
+
 	assert.Equal(t, false, result, "Expected an error.")
 }
 
 func TestPutToFile(t *testing.T) {
 	filename := createFile()
+	loadConfig()
 
 	// Parse arguments
 	os.Args = []string{"taskcluster", "s3", "put", filename, "test-bucket-for-any-garbage", "folder1/folder2/testFile.txt"}
@@ -172,22 +141,8 @@ func TestPutToFile(t *testing.T) {
 		fmt.Println("Failed to parse arguments")
 	}
 
-	// Load configuration
-	config, err := config.Load()
-	if err != nil {
-		fmt.Println("Failed to load configuration file, error: ", err)
-	}
-
-	// Set context
-	var context extpoints.Context
 	context.Arguments = arguments
-	context.Config = nil
-	context.Credentials = &client.Credentials{
-		ClientID:    config["config"]["clientId"].(string),
-		AccessToken: config["config"]["accessToken"].(string),
-		Certificate: config["config"]["certificate"].(string),
-	}
-
 	result := s3Test.Execute(context)
+
 	assert.Equal(t, true, result, "An error occured during execution.")
 }

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -1,0 +1,134 @@
+package s3
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docopt/docopt-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster-cli/client"
+	"github.com/taskcluster/taskcluster-cli/config"
+	"github.com/taskcluster/taskcluster-cli/extpoints"
+	"github.com/taskcluster/taskcluster-cli/version"
+)
+
+func TestPutFolder1Folder2(t *testing.T) {
+	// Initial setup
+	var s3Test S3
+
+	// Create a file to upload
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("Error occured: ", err)
+	}
+
+	// Create filepath
+	filename := filepath.Join(pwd, "testFile.txt")
+	if err := os.MkdirAll(filepath.Dir(filename), 0775); err != nil {
+		fmt.Println("Unable to create directory: ", err)
+	}
+
+	// Setup the local file
+	file, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// Write to file
+	data := []byte("Hello World")
+	file.Write(data)
+
+	// Parse arguments
+	os.Args = []string{"taskcluster", "s3", "put", "testFile.txt", "test-bucket-for-any-garbage", "folder1/folder2/"}
+	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
+	if err != nil {
+		fmt.Println("Failed to parse arguments")
+	}
+
+	// Load configuration
+	config, err := config.Load()
+	if err != nil {
+		fmt.Println("Failed to load configuration file, error: ", err)
+	}
+
+	// context given to Execute
+	var context extpoints.Context
+	context.Arguments = arguments
+	context.Config = nil
+	context.Credentials = &client.Credentials{
+		ClientID:    config["config"]["clientId"].(string),
+		AccessToken: config["config"]["accessToken"].(string),
+		Certificate: config["config"]["certificate"].(string),
+	}
+
+	result := s3Test.Execute(context)
+
+	assert.Equal(t, true, result, "An error occured during execution.")
+}
+
+func TestGetFolder1Folder2(t *testing.T) {
+	// Initial Setup
+	var s3Test S3
+
+	// Parse arguments
+	os.Args = []string{"taskcluster", "s3", "get", "testFile.txt", "test-bucket-for-any-garbage", "folder1/folder2/"}
+	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
+	if err != nil {
+		fmt.Println("Failed to parse arguments")
+	}
+
+	// Load configuration
+	config, err := config.Load()
+	if err != nil {
+		fmt.Println("Failed to load configuration file, error: ", err)
+	}
+
+	// context given to Execute
+	var context extpoints.Context
+	context.Arguments = arguments
+	context.Config = nil
+	context.Credentials = &client.Credentials{
+		ClientID:    config["config"]["clientId"].(string),
+		AccessToken: config["config"]["accessToken"].(string),
+		Certificate: config["config"]["certificate"].(string),
+	}
+
+	result := s3Test.Execute(context)
+
+	assert.Equal(t, true, result, "An error occured during execution.")
+}
+
+func TestGetFolder1(t *testing.T) {
+	// Initial Setup
+	var s3Test S3
+
+	// Parse arguments
+	os.Args = []string{"taskcluster", "s3", "get", "testFile.txt", "test-bucket-for-any-garbage", "folder1/"}
+	arguments, err := docopt.Parse(usage(), nil, true, version.VersionNumber, true)
+	if err != nil {
+		fmt.Println("Failed to parse arguments")
+	}
+
+	// Load configuration
+	config, err := config.Load()
+	if err != nil {
+		fmt.Println("Failed to load configuration file, error: ", err)
+	}
+
+	// context given to Execute
+	var context extpoints.Context
+	context.Arguments = arguments
+	context.Config = nil
+	context.Credentials = &client.Credentials{
+		ClientID:    config["config"]["clientId"].(string),
+		AccessToken: config["config"]["accessToken"].(string),
+		Certificate: config["config"]["certificate"].(string),
+	}
+
+	result := s3Test.Execute(context)
+
+	assert.Equal(t, false, result, "Expected an error.")
+}

--- a/subtree_imports.go
+++ b/subtree_imports.go
@@ -2,4 +2,8 @@
 package main
 
 import _ "github.com/taskcluster/taskcluster-cli/apis"
+import _ "github.com/taskcluster/taskcluster-cli/client"
+import _ "github.com/taskcluster/taskcluster-cli/config"
 import _ "github.com/taskcluster/taskcluster-cli/extpoints"
+import _ "github.com/taskcluster/taskcluster-cli/s3"
+import _ "github.com/taskcluster/taskcluster-cli/version"


### PR DESCRIPTION
The command can be used to upload/download file to AWS S3 using:
-  `taskcluster s3 upload <file> <region> <level> <bucket> <prefix>`
-  `taskcluster s3 download <key> <region> <level> <bucket> <prefix>`

I was (obviously) not able to test it since I don't have the required credentials (I get a HTTP 401 error). So what should be my next step to go about this?

Also, I faced one issue. `AWSS3CredentialsResponse` has an `Expires` field which returns  `tcclient.Time`. But `UploadInput` has an `Expires` field which takes `*time.Time` as mentioned [here](http://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#UploadInput). I am a little confused about how to convert it. Any pointers on how to achieve this? 

The AWS SDK handles exponential backoff, multi part upload, etc.

This PR addresses issue(#28). /cc @walac 
