### PR TITLE
command to download with automatic retries

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -1,0 +1,35 @@
+package download
+
+import "github.com/alexandrasp/taskcluster-cli/extpoints"
+
+//"github.com/taskcluster/httpbackoff"
+
+func init() {
+	extpoints.Register("download", download{})
+}
+
+type download struct{}
+
+func (download) ConfigOptions() map[string]extpoints.ConfigOption {
+	return nil
+}
+
+func (download) Summary() string {
+	return "Download an artifact"
+}
+
+func (download) Usage() string {
+	usage := "How you can download a taskcluster CLI artifact.\n"
+	usage += "\n"
+	usage += "Usage:\n"
+	usage += "taskcluster download [options]"
+	usage += "\n"
+	usage += "Options:"
+	usage += "\n"
+	return usage
+}
+
+func (download) Execute(extpoints.Context) bool {
+
+	return false
+}

--- a/download/download.go
+++ b/download/download.go
@@ -95,7 +95,7 @@ func getAnArtifact(url string) {
 
 	} else {
 
-		fmt.Sscan("%d Retries", attempts)
+		fmt.Printf("Number of attempts: %d\n", attempts)
 		fmt.Printf("%+v\n", res)
 
 	}

--- a/download/download.go
+++ b/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -38,6 +39,7 @@ func usageDownload() string {
 func (download) Usage() string {
 	return usageDownload()
 }
+
 func (download) Execute(context extpoints.Context) bool {
 	command := context.Arguments["download"].(string)
 	taskId := context.Arguments["<taskId>"].(string)
@@ -54,6 +56,7 @@ func (download) Execute(context extpoints.Context) bool {
 			ClientID:    "tester",
 			AccessToken: "no-secret",
 		}
+
 		userQueue := queue.New(permaCred)
 
 		if runId != "" {
@@ -62,13 +65,7 @@ func (download) Execute(context extpoints.Context) bool {
 			if err != nil {
 				log.Panicf("Exception thrown signing URL \n%s", err)
 			} else {
-
-				//download with automatic retries
-				res, attempts, err := httpbackoff.Retry(func() (*http.Response, error, error) {
-					resp, err := http.Get(url_artifact.String())
-					// assume all errors are temporary
-					return resp, err, nil
-				})
+				getAnArtifact(url_artifact.String())
 			}
 		}
 		if runId == "" {
@@ -77,14 +74,30 @@ func (download) Execute(context extpoints.Context) bool {
 			if err != nil {
 				log.Panicf("Exception thrown signing URL \n%s", err)
 			} else {
-				res, attempts, err := httpbackoff.Retry(func() (*http.Response, error, error) {
-					resp, err := http.Get(url_artifact.String())
-					// assume all errors are temporary
-					return resp, err, nil
-				})
+				getAnArtifact(url_artifact.String())
 			}
 		}
 
 	}
 	return false
+}
+
+func getAnArtifact(url string) {
+	res, attempts, err := httpbackoff.Retry(func() (*http.Response, error, error) {
+		resp, err := http.Get(url)
+		// assume all errors are temporary
+		return resp, err, nil
+	})
+
+	if err != nil {
+
+		log.Panicf("Exception thrown download an artifact \n%s", err)
+
+	} else {
+
+		fmt.Sscan("%d Retries", attempts)
+		fmt.Printf("%+v\n", res)
+
+	}
+
 }

--- a/download/download.go
+++ b/download/download.go
@@ -52,12 +52,25 @@ func (download) Execute(context extpoints.Context) bool {
 			ClientID:    "tester",
 			AccessToken: "no-secret",
 		}
-
 		userQueue := queue.New(permaCred)
-		url_artifact, err := userQueue.GetArtifact_SignedURL(taskId, runId, artifact, time.Second*300)
 
-		if err != nil {
-			log.Panicf("Exception thrown signing URL \n%s", err)
+		if runId != "" {
+			//get a artifact with runId parameter
+			url_artifact, err := userQueue.GetArtifact_SignedURL(taskId, runId, artifact, time.Second*300)
+			if err != nil {
+				log.Panicf("Exception thrown signing URL \n%s", err)
+			} else {
+
+			}
+		}
+		if runId == "" {
+			//get latest artifact without rundId parameter
+			url_artifact, err := userQueue.GetLatestArtifact_SignedURL(taskId, artifact, time.Second*300)
+			if err != nil {
+				log.Panicf("Exception thrown signing URL \n%s", err)
+			} else {
+
+			}
 		}
 
 	}


### PR DESCRIPTION
The first part of download command implementation. It is a new implementation from Command Provider interface, to do request from a URL and download a artifact from this by automatic retries. 