### PR TITLE
Authentication for API commands doesn't match the server's expected format

### DIFF
--- a/client/credentials.go
+++ b/client/credentials.go
@@ -82,11 +82,7 @@ func (c *Credentials) newAuth(method, url string, h hash.Hash) (*hawk.Auth, erro
 	}
 	if e.Certificate != nil || e.AuthorizedScopes != nil {
 		s, _ := json.Marshal(e)
-		if string(s) != "{}" {
-			a.Ext = base64.StdEncoding.EncodeToString(s)
-		} else {
-			a.Ext = string(s)
-		}
+		a.Ext = base64.StdEncoding.EncodeToString(s)
 	}
 
 	// Set payload hash

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -82,7 +82,11 @@ func (c *Credentials) newAuth(method, url string, h hash.Hash) (*hawk.Auth, erro
 	}
 	if e.Certificate != nil || e.AuthorizedScopes != nil {
 		s, _ := json.Marshal(e)
-		a.Ext = string(s)
+		if string(s) != "{}" {
+			a.Ext = base64.StdEncoding.EncodeToString(s)
+		} else {
+			a.Ext = string(s)
+		}
 	}
 
 	// Set payload hash


### PR DESCRIPTION
Any command that uses the auto-generated API commands with authentication will not work because the `ext` parameter of the hawk `Authorization` header is not base64 encoded.