### PR TITLE
Prepare configuration for transition to cobra

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+    "fmt"
+    "os"
+
+	"github.com/taskcluster/taskcluster-cli/client"
+)
+
+var (
+    Configuration map[string]map[string]interface{}
+    ConfigOptions = make(map[string]map[string]ConfigOption)
+    Credentials *client.Credentials
+)
+
+// Setup: call it from main
+// this was originally the init() function
+// but we want to make sure all other packages have been initialized
+// before calling them, which Load() does
+func Setup() {
+    var err error
+
+    // load configuration
+    Configuration, err = Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load configuration file, error: %s\n", err)
+		os.Exit(1)
+	}
+
+    // load credentials
+    clientID, ok1 := Configuration["config"]["clientId"].(string)
+	accessToken, ok2 := Configuration["config"]["accessToken"].(string)
+	if ok1 && ok2 {
+		certificate, _ := Configuration["config"]["certificate"].(string)
+		authorizedScopes, _ := Configuration["config"]["authorizedScopes"].([]string)
+		Credentials = &client.Credentials{
+			ClientID:         clientID,
+			AccessToken:      accessToken,
+			Certificate:      certificate,
+			AuthorizedScopes: authorizedScopes,
+		}
+	}
+}

--- a/config/init.go
+++ b/config/init.go
@@ -9,11 +9,11 @@ import (
 
 var (
 	Configuration map[string]map[string]interface{}
-	ConfigOptions = make(map[string]map[string]ConfigOption)
+	OptionsDefinitions = make(map[string]map[string]OptionDefinition)
 	Credentials   *client.Credentials
 )
 
-// Setup: call it from main
+// Setup is to be called from main
 // this was originally the init() function
 // but we want to make sure all other packages have been initialized
 // before calling them, which Load() does

--- a/config/init.go
+++ b/config/init.go
@@ -1,16 +1,16 @@
 package config
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
 	"github.com/taskcluster/taskcluster-cli/client"
 )
 
 var (
-    Configuration map[string]map[string]interface{}
-    ConfigOptions = make(map[string]map[string]ConfigOption)
-    Credentials *client.Credentials
+	Configuration map[string]map[string]interface{}
+	ConfigOptions = make(map[string]map[string]ConfigOption)
+	Credentials   *client.Credentials
 )
 
 // Setup: call it from main
@@ -18,17 +18,17 @@ var (
 // but we want to make sure all other packages have been initialized
 // before calling them, which Load() does
 func Setup() {
-    var err error
+	var err error
 
-    // load configuration
-    Configuration, err = Load()
+	// load configuration
+	Configuration, err = Load()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load configuration file, error: %s\n", err)
 		os.Exit(1)
 	}
 
-    // load credentials
-    clientID, ok1 := Configuration["config"]["clientId"].(string)
+	// load credentials
+	clientID, ok1 := Configuration["config"]["clientId"].(string)
 	accessToken, ok2 := Configuration["config"]["accessToken"].(string)
 	if ok1 && ok2 {
 		certificate, _ := Configuration["config"]["certificate"].(string)

--- a/config/option.go
+++ b/config/option.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+    "github.com/taskcluster/taskcluster-cli/extpoints"
+)
+
+type ConfigOption struct {
+	Description string      // Description of the config option
+	Default     interface{} // Default value
+	Env         string      // Environment variable to attempt to load from (optional)
+	Parse       bool        // True, if string input should be parsed as JSON
+	Validate    func(value interface{}) error
+}
+
+// Register takes in the name of the command and a ConfigOption object
+func Register(command string, options map[string]ConfigOption) {
+    if _, exists := ConfigOptions[command]; !exists {
+        ConfigOptions[command] = make(map[string]ConfigOption)
+    }
+
+    // we could just copy 'options' but sometimes there might already be other options
+    for key, option := range options {
+        ConfigOptions[command][key] = option
+    }
+}
+
+// To register the ConfigOptions from a CommandProvider
+// this is a function used for the "transition"
+func RegisterFromProvider(command string, options map[string]extpoints.ConfigOption) {
+    if _, exists := ConfigOptions[command]; !exists {
+        ConfigOptions[command] = make(map[string]ConfigOption)
+    }
+
+    for key, option := range options {
+        ConfigOptions[command][key] = ConfigOption{
+            Description: option.Description,
+            Default:     option.Default,
+            Env:         option.Env,
+            Parse:       option.Parse,
+            Validate:    option.Validate,
+        }
+    }
+}

--- a/config/option.go
+++ b/config/option.go
@@ -4,9 +4,9 @@ import (
 	"github.com/taskcluster/taskcluster-cli/extpoints"
 )
 
-// A ConfigOption is something with a default value and a validator.
+// A OptionDefinition is something with a default value and a validator.
 // Only requirement is that values are JSON structures.
-type ConfigOption struct {
+type OptionDefinition struct {
 	Description string      // Description of the config option
 	Default     interface{} // Default value
 	Env         string      // Environment variable to attempt to load from (optional)
@@ -14,27 +14,27 @@ type ConfigOption struct {
 	Validate    func(value interface{}) error
 }
 
-// Register takes in the name of the command and a ConfigOption object
-func RegisterConfigOption(command string, options map[string]ConfigOption) {
-	if _, exists := ConfigOptions[command]; !exists {
-		ConfigOptions[command] = make(map[string]ConfigOption)
+// Register takes in the name of the command and an OptionDefinition object
+func RegisterConfigOption(command string, options map[string]OptionDefinition) {
+	if _, exists := OptionsDefinitions[command]; !exists {
+		OptionsDefinitions[command] = make(map[string]OptionDefinition)
 	}
 
 	// we could just copy 'options' but sometimes there might already be other options
 	for key, option := range options {
-		ConfigOptions[command][key] = option
+		OptionsDefinitions[command][key] = option
 	}
 }
 
-// To register the ConfigOptions from a CommandProvider
+// To register the OptionsDefinitions from a CommandProvider
 // this is a function used for the "transition"
 func RegisterFromProvider(command string, options map[string]extpoints.ConfigOption) {
-	if _, exists := ConfigOptions[command]; !exists {
-		ConfigOptions[command] = make(map[string]ConfigOption)
+	if _, exists := OptionsDefinitions[command]; !exists {
+		OptionsDefinitions[command] = make(map[string]OptionDefinition)
 	}
 
 	for key, option := range options {
-		ConfigOptions[command][key] = ConfigOption{
+		OptionsDefinitions[command][key] = OptionDefinition{
 			Description: option.Description,
 			Default:     option.Default,
 			Env:         option.Env,

--- a/config/option.go
+++ b/config/option.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-    "github.com/taskcluster/taskcluster-cli/extpoints"
+	"github.com/taskcluster/taskcluster-cli/extpoints"
 )
 
+// A ConfigOption is something with a default value and a validator.
+// Only requirement is that values are JSON structures.
 type ConfigOption struct {
 	Description string      // Description of the config option
 	Default     interface{} // Default value
@@ -13,31 +15,31 @@ type ConfigOption struct {
 }
 
 // Register takes in the name of the command and a ConfigOption object
-func Register(command string, options map[string]ConfigOption) {
-    if _, exists := ConfigOptions[command]; !exists {
-        ConfigOptions[command] = make(map[string]ConfigOption)
-    }
+func RegisterConfigOption(command string, options map[string]ConfigOption) {
+	if _, exists := ConfigOptions[command]; !exists {
+		ConfigOptions[command] = make(map[string]ConfigOption)
+	}
 
-    // we could just copy 'options' but sometimes there might already be other options
-    for key, option := range options {
-        ConfigOptions[command][key] = option
-    }
+	// we could just copy 'options' but sometimes there might already be other options
+	for key, option := range options {
+		ConfigOptions[command][key] = option
+	}
 }
 
 // To register the ConfigOptions from a CommandProvider
 // this is a function used for the "transition"
 func RegisterFromProvider(command string, options map[string]extpoints.ConfigOption) {
-    if _, exists := ConfigOptions[command]; !exists {
-        ConfigOptions[command] = make(map[string]ConfigOption)
-    }
+	if _, exists := ConfigOptions[command]; !exists {
+		ConfigOptions[command] = make(map[string]ConfigOption)
+	}
 
-    for key, option := range options {
-        ConfigOptions[command][key] = ConfigOption{
-            Description: option.Description,
-            Default:     option.Default,
-            Env:         option.Env,
-            Parse:       option.Parse,
-            Validate:    option.Validate,
-        }
-    }
+	for key, option := range options {
+		ConfigOptions[command][key] = ConfigOption{
+			Description: option.Description,
+			Default:     option.Default,
+			Env:         option.Env,
+			Parse:       option.Parse,
+			Validate:    option.Validate,
+		}
+	}
 }

--- a/config/serialization.go
+++ b/config/serialization.go
@@ -42,7 +42,7 @@ func Load() (map[string]map[string]interface{}, error) {
 	}
 
 	// Load all the default values
-	for name, options := range ConfigOptions {
+	for name, options := range OptionsDefinitions {
 		config[name] = make(map[string]interface{})
 		for key, option := range options {
 			config[name][key] = option.Default
@@ -60,7 +60,7 @@ func Load() (map[string]map[string]interface{}, error) {
 	}
 
 	// Load values from environment variables when applicable
-	for name, options := range ConfigOptions {
+	for name, options := range OptionsDefinitions {
 		for key, option := range options {
 			// Get from env var if possible and available
 			if option.Env == "" {
@@ -97,7 +97,7 @@ func Load() (map[string]map[string]interface{}, error) {
 	}
 
 	// Validate all values that have a validator and isn't the default value
-	for name, options := range ConfigOptions {
+	for name, options := range OptionsDefinitions {
 		for key, option := range options {
 			value := config[name][key]
 			if reflect.DeepEqual(value, option.Default) || option.Validate == nil {
@@ -128,7 +128,7 @@ func Save(config map[string]map[string]interface{}) error {
 	}
 
 	// go over new object
-	for name, options := range ConfigOptions {
+	for name, options := range OptionsDefinitions {
 		for key, option := range options {
 			value := config[name][key]
 			// Skip default values, no need to save those

--- a/config/serialization.go
+++ b/config/serialization.go
@@ -34,10 +34,17 @@ func configFile() string {
 func Load() (map[string]map[string]interface{}, error) {
 	config := make(map[string]map[string]interface{})
 
-	// Load all the default values
+	// transfer everything from the providers
+	// into the new ConfigOptions object
+	// temporary for "transition"
 	for name, provider := range extpoints.CommandProviders() {
+		RegisterFromProvider(name, provider.ConfigOptions())
+	}
+
+	// Load all the default values
+	for name, options := range ConfigOptions {
 		config[name] = make(map[string]interface{})
-		for key, option := range provider.ConfigOptions() {
+		for key, option := range options {
 			config[name][key] = option.Default
 		}
 	}
@@ -53,8 +60,8 @@ func Load() (map[string]map[string]interface{}, error) {
 	}
 
 	// Load values from environment variables when applicable
-	for name, provider := range extpoints.CommandProviders() {
-		for key, option := range provider.ConfigOptions() {
+	for name, options := range ConfigOptions {
+		for key, option := range options {
 			// Get from env var if possible and available
 			if option.Env == "" {
 				continue
@@ -90,8 +97,8 @@ func Load() (map[string]map[string]interface{}, error) {
 	}
 
 	// Validate all values that have a validator and isn't the default value
-	for name, provider := range extpoints.CommandProviders() {
-		for key, option := range provider.ConfigOptions() {
+	for name, options := range ConfigOptions {
+		for key, option := range options {
 			value := config[name][key]
 			if reflect.DeepEqual(value, option.Default) || option.Validate == nil {
 				continue
@@ -113,8 +120,16 @@ func Load() (map[string]map[string]interface{}, error) {
 func Save(config map[string]map[string]interface{}) error {
 	result := make(map[string]map[string]interface{})
 
+	// transfer everything from the providers
+	// into the new ConfigOptions object
+	// temporary for "transition"
 	for name, provider := range extpoints.CommandProviders() {
-		for key, option := range provider.ConfigOptions() {
+		RegisterFromProvider(name, provider.ConfigOptions())
+	}
+
+	// go over new object
+	for name, options := range ConfigOptions {
+		for key, option := range options {
 			value := config[name][key]
 			// Skip default values, no need to save those
 			if reflect.DeepEqual(value, option.Default) {

--- a/extpoints/interfaces.go
+++ b/extpoints/interfaces.go
@@ -4,6 +4,8 @@ import "github.com/taskcluster/taskcluster-cli/client"
 
 // A ConfigOption is something with a default value and a validator.
 // Only requirement is that values are JSON structures.
+// NOTE: this struct is temporary and will soon be replaced with its equivalent
+//		 (same name, same everything) in package `config`
 type ConfigOption struct {
 	Description string      // Description of the config option
 	Default     interface{} // Default value

--- a/extpoints/interfaces.go
+++ b/extpoints/interfaces.go
@@ -5,7 +5,7 @@ import "github.com/taskcluster/taskcluster-cli/client"
 // A ConfigOption is something with a default value and a validator.
 // Only requirement is that values are JSON structures.
 // NOTE: this struct is temporary and will soon be replaced with its equivalent
-//		 (same name, same everything) in package `config`
+//		 (config.OptionDefinition, everything the same) in package `config`
 type ConfigOption struct {
 	Description string      // Description of the config option
 	Default     interface{} // Default value

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 		provider.Usage(), append([]string{cmd}, args...),
 		true, version.VersionNumber, false,
 	)
-	
+
 	// set up the whole config thing
 	config.Setup()
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
-	"github.com/taskcluster/taskcluster-cli/client"
 	"github.com/taskcluster/taskcluster-cli/config"
 	"github.com/taskcluster/taskcluster-cli/extpoints"
 	"github.com/taskcluster/taskcluster-cli/version"
@@ -44,13 +43,6 @@ func availableCommands() string {
 }
 
 func main() {
-	// Load config file
-	config, err := config.Load()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to load configuration file, error: %s\n", err)
-		os.Exit(1)
-	}
-
 	// Construct usage string
 	usage := "Usage: taskcluster [options] <command> [<args>...]\n"
 	usage += "\n"
@@ -88,28 +80,17 @@ func main() {
 		provider.Usage(), append([]string{cmd}, args...),
 		true, version.VersionNumber, false,
 	)
-
-	// Create credentials, if available in configuration
-	var credentials *client.Credentials
-	clientID, ok1 := config["config"]["clientId"].(string)
-	accessToken, ok2 := config["config"]["accessToken"].(string)
-	if ok1 && ok2 {
-		certificate, _ := config["config"]["certificate"].(string)
-		authorizedScopes, _ := config["config"]["authorizedScopes"].([]string)
-		credentials = &client.Credentials{
-			ClientID:         clientID,
-			AccessToken:      accessToken,
-			Certificate:      certificate,
-			AuthorizedScopes: authorizedScopes,
-		}
-	}
+	
+	// set up the whole config thing
+	config.Setup()
 
 	// Execute provider with parsed args
 	success := provider.Execute(extpoints.Context{
 		Arguments:   subArguments,
-		Config:      config[cmd],
-		Credentials: credentials,
+		Config:      config.Configuration[cmd],
+		Credentials: config.Credentials,
 	})
+
 	if success {
 		os.Exit(0)
 	} else {


### PR DESCRIPTION
This is mostly refactoring.

I moved the configuration and credentials from the `main()` function to the `config` package and everything gets accessed from there. Now, you simply call `config.Setup()` from `main()`.

A dedicated object to hold `ConfigOption`s has been created, with a function to register new options. It is also wired to integrate with `CommandProvider`s until all the commands have moved to the new process for registering options.

Everything looks good on my end, but since I'm playing in an area of the code I don't know really well you might want to take a closer look by pulling the branch.

This will complete step 1 of the [Transition Plan](https://github.com/taskcluster/taskcluster-cli/wiki/Transition-plan-from-docopt-to-cobra).