### PR TITLE
Replace `tctalker`

### DIFF
--- a/group/actions.go
+++ b/group/actions.go
@@ -1,0 +1,95 @@
+package group
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
+)
+
+type arguments map[string]interface{}
+
+// SubCommand represents the function interface of the task subcommand.
+type SubCommand func(credentials *tcclient.Credentials, args arguments) bool
+
+func runCancel(credentials *tcclient.Credentials, args arguments) bool {
+	q := queue.New(credentials)
+	groupID := args["<groupId>"].(string)
+
+	tasks := make([]string, 0)
+	continuation := ""
+	for {
+		ts, err := q.ListTaskGroup(groupID, continuation, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: could not fetch tasks for group %s: %v", groupID, err)
+			return false
+		}
+
+		for _, t := range ts.Tasks {
+			if t.Status.State == "unscheduled" || t.Status.State == "pending" || t.Status.State == "running" {
+				tasks = append(tasks, t.Status.TaskID)
+			}
+		}
+
+		continuation = ts.ContinuationToken
+		if continuation == "" {
+			break
+		}
+	}
+
+	// Here we use a waitgroup to ensure that we return once all the tasks have
+	// been completed.
+	wg := &sync.WaitGroup{}
+	// The context allows us to exit early if any of the cancellation fails.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, taskID := range tasks {
+		wg.Add(1)
+		go func(taskID string) {
+			// If we paniced on the way out, abort all the other tasks.
+			defer func() {
+				//recover from panic and abort
+				if err := recover(); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					cancel()
+				}
+			}()
+
+			fmt.Printf("cancelling task %s\n", taskID)
+			c := make(chan error, 1)
+			go func() { _, err := q.CancelTask(taskID); c <- err }()
+
+			// we select the first that returns or closes:
+			// - ctx.Done() if we aborted;
+			// - c if we got a completed cancellation.
+			select {
+			case <-ctx.Done():
+				// nothing
+			case err := <-c:
+				if err != nil {
+					panic(fmt.Errorf("could not cancel task %s: %v", taskID, err))
+				}
+			}
+			// if we exited normally, we indicate that we completed.
+			wg.Done()
+		}(taskID)
+	}
+	// change the semantics o the waitgroup to close a channel instead
+	regularExit := make(chan bool, 0)
+	go func() { wg.Wait(); close(regularExit) }()
+
+	// We select the first that closes:
+	// - ctx.Done() if we aborted;
+	// - regularExit if all the goroutine exited manually.
+	select {
+	case <-ctx.Done():
+		fmt.Fprintln(os.Stderr, "error: could not cancel all tasks")
+		return false
+	case <-regularExit:
+		return true
+	}
+}

--- a/group/group.go
+++ b/group/group.go
@@ -25,7 +25,7 @@ func (cmd) Usage() string {
 	return `Group related actions.
 
 Usage:
-  groupcluster group cancel [--] <groupId>
+  taskcluster group cancel [--] <groupId>
 `
 }
 

--- a/group/group.go
+++ b/group/group.go
@@ -1,0 +1,50 @@
+package group
+
+import (
+	"github.com/taskcluster/taskcluster-cli/extpoints"
+
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+)
+
+func init() {
+	extpoints.Register("group", cmd{})
+}
+
+type cmd struct {
+}
+
+func (cmd) ConfigOptions() map[string]extpoints.ConfigOption {
+	return nil
+}
+
+func (cmd) Summary() string {
+	return "Group related actions."
+}
+
+func (cmd) Usage() string {
+	return `Group related actions.
+
+Usage:
+  groupcluster group cancel [--] <groupId>
+`
+}
+
+func (cmd) Execute(context extpoints.Context) bool {
+	args := context.Arguments
+
+	if args["cancel"].(bool) {
+		return executeSubCommand(context, runCancel)
+	}
+
+	return false
+}
+
+// executeSubCommand executes the given SubCommand.
+func executeSubCommand(context extpoints.Context, subCommand SubCommand) bool {
+	var c *tcclient.Credentials
+	if context.Credentials != nil {
+		c = context.Credentials.ToClientCredentials()
+	}
+
+	return subCommand(c, context.Arguments)
+}

--- a/subtree_imports.go
+++ b/subtree_imports.go
@@ -6,6 +6,7 @@ package main
 import _ "github.com/taskcluster/taskcluster-cli/apis"
 import _ "github.com/taskcluster/taskcluster-cli/config"
 import _ "github.com/taskcluster/taskcluster-cli/from-now"
+import _ "github.com/taskcluster/taskcluster-cli/group"
 import _ "github.com/taskcluster/taskcluster-cli/task"
 import _ "github.com/taskcluster/taskcluster-cli/version"
 import _ "github.com/taskcluster/taskcluster-cli/slugid"


### PR DESCRIPTION
Release engineering has built a Python app to do some taskcluster chores:
  https://github.com/mozilla/tctalker/blob/master/src/tctalker/tctalker.py
We should support that functionality directly.

* `tctalker status` is covered by #23 
* `tctalker cancel` is as simple as `taskcluster api queue cancelTask $TASKID`
* `tctalker rerun` is  as simple as `taskcluster api queue rerunTask $TASKID`
* `tctalker report_completed` would make a good new command
* `tctalker cancel_graph` too.  Note that it uses the deprecated scheduler API.  A better choice would be to list all tasks in the given taskGroupId and cancel those which are not complete.