### PR TITLE
add a build that uploads artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,7 +1,7 @@
 version: 0
 metadata:
-  name: "TaskCluster GitHub Tests"
-  description: "All non-integration tests for taskcluster github"
+  name: "TaskCluster .taskcluster.yml file"
+  description: "Tasks for taskcluster-cli"
   owner: "{{ event.head.user.email }}"
   source: "{{ event.head.repo.url }}"
 tasks:
@@ -36,7 +36,36 @@ tasks:
           --enable=vet --enable=vetshadow --enable=gosimple
           --skip=apis --skip=vendor ./...
     metadata:
-      name: "TaskCluster .taskcluster.yml file"
+      name: "TaskCluster GitHub Tests"
       description: "All non-integration tests"
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    extra:
+      github:
+        env: true
+        events:
+          # TODO: tag - https://bugzilla.mozilla.org/show_bug.cgi?id=1344912
+          - release
+    payload:
+      maxRunTime: 3600
+      image: 'golang:1.8'
+      command:
+        - /bin/bash
+        - '-c'
+        - >-
+          go get -t github.com/taskcluster/taskcluster-cli/...
+          && cd  /go/src/github.com/taskcluster/taskcluster-cli
+          && git fetch {{ event.head.repo.url }} {{ event.head.ref }}
+          && git checkout {{ event.head.sha }}
+          && make taskcluster
+      artifacts:
+        public/taskcluster-linux:
+          path: /go/src/github.com/taskcluster/taskcluster-cli/taskcluster
+          type: file
+    metadata:
+      name: "Build a binary for release"
+      description: "Binary release"
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ BINARY = taskcluster
 
 # Flags that are to be passed to the linker, can be overwritten by
 # the environment or as an argument to make.
-LDFLAGS ?= ""
+LDFLAGS ?=
 
 SOURCEDIR = .
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
+
+VERSION := $(shell git describe --always  --dirty --tags)
+LDFLAGS += -X github.com/taskcluster/taskcluster-cli/cmds/version.VersionNumber=$(VERSION)
 
 all: prep build
 
@@ -17,7 +20,7 @@ prep:
 build: $(BINARY)
 
 $(BINARY): $(SOURCES)
-	go build -ldflags ${LDFLAGS} -o ${BINARY} .
+	go build -ldflags "${LDFLAGS}" -o ${BINARY} .
 
 clean:
 	rm -f ${BINARY}

--- a/cmds/config/get.go
+++ b/cmds/config/get.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/taskcluster/taskcluster-cli/cmds/root"
 )
 
 func init() {
@@ -16,7 +17,7 @@ func init() {
 	cmd.Flags().StringP("output", "o", "", "Write output to file [default: -]")
 	cmd.Flags().StringP("format", "f", "yaml", "Select output format [default: yaml]")
 
-	Command.AddCommand(cmd)
+	root.Command.AddCommand(cmd)
 }
 
 func cmdGet(cmd *cobra.Command, args []string) error {

--- a/cmds/version/version.go
+++ b/cmds/version/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"github.com/taskcluster/taskcluster-cli/cmds/root"
 )
 
@@ -16,8 +15,9 @@ var (
 		Run:   printVersion,
 	}
 
-	// VersionNumber is a formatted string with the version information.
-	VersionNumber = "1.0.0"
+	// VersionNumber is a formatted string with the version information. This is
+	// filled in by the Makefile
+	VersionNumber string
 )
 
 func init() {


### PR DESCRIPTION
This task, when complete, should have a `taskcluster-linux` artifact containing an executable binary.  The idea is that we can add a darwin (OS X) and windows binary, too, using similar tasks.

When this is set, I'll change it to run on releases, rather than on pull requests (which should still just run tests).