### PR TITLE
Use backwards compatible version of package 'context'

### DIFF
--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -1,7 +1,6 @@
 package group
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -9,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
+	"golang.org/x/net/context"
 )
 
 // runCancel cancels all tasks of a group.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -135,6 +135,12 @@
 			"revisionTime": "2017-02-25T17:21:24Z"
 		},
 		{
+			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
+			"path": "golang.org/x/net/context",
+			"revision": "d379faa25cbdc04d653984913a2ceb43b0bc46d7",
+			"revisionTime": "2017-01-16T00:30:03Z"
+		},
+		{
 			"checksumSHA1": "O9E8G234qCcPA7f7srGpnawDmMs=",
 			"path": "gopkg.in/tylerb/graceful.v1",
 			"revision": "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb",


### PR DESCRIPTION
This is an optional change that would enable us to compile with older versions of Go.

_Details:_

Currently, the file **cmds/group/actors.go** imports package `context`. However, that package is only available "natively" in Go starting at version 1.7 (I believe).

Older versions of Go can access the `context` package by importing `golang.org/x/net/context`. Everything else will work the same.

This change makes tc-cli use the latter form (long URL) so older versions of Go can compile the program. Of which version 1.5.1, the current version available in Ubuntu's (and perhaps others') default repositories. Users that want a later version of Go must install it manually. It's up to us to decide whether we want to force users to install Go > 1.7 - potentially manually - or keep backwards compatibility. I've also added that point to Friday's meeting.