### PR TITLE
Fix stupid

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ func main() {
 
 	// gentlemen, START YOUR ENGINES
 	if err := root.Command.Execute(); err != nil {
-		os.Exit(0)
-	} else {
 		os.Exit(1)
+	} else {
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
Nothing to see here really.

Turns out you exit with 1 when there is an error and 0 when there is not, not vice-versa.

P.S. don't worry about feeling stupid, _I_ was the one who originally wrote this.