### PR TITLE
Don't fetch subpackages in the first `go get`

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,7 +21,7 @@ tasks:
         - /bin/bash
         - '-c'
         - >-
-          go get -t github.com/taskcluster/taskcluster-cli/... 
+          go get -t github.com/taskcluster/taskcluster-cli
           && cd  /go/src/github.com/taskcluster/taskcluster-cli 
           && git fetch {{ event.head.repo.url }} {{ event.head.ref }} 
           && git checkout {{ event.head.sha }} 

--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -90,7 +90,7 @@ func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, 
 	}
 	// change the semantics of waitgroup to close a channel instead of blocking
 	// the main thread.
-	regularExit := make(chan bool, 0)
+	regularExit := make(chan bool)
 	go func() { wg.Wait(); close(regularExit) }()
 
 	// We select the first that closes:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,8 +63,32 @@
 			"revisionTime": "2017-01-30T21:42:45Z"
 		},
 		{
+			"checksumSHA1": "K0crHygPTP42i1nLKWphSlvOQJw=",
+			"path": "github.com/stretchr/objx",
+			"revision": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94",
+			"revisionTime": "2015-09-28T12:21:52Z"
+		},
+		{
+			"checksumSHA1": "/kKwYqD04AkkDZFQhGwklKw3RFA=",
+			"path": "github.com/stretchr/testify",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
 			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",
 			"path": "github.com/stretchr/testify/assert",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "fg3TzS9/QK3wZbzei3Z6O8XPLHg=",
+			"path": "github.com/stretchr/testify/http",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "WGwMB6WljaeGKzuNCX5M4E8LADE=",
+			"path": "github.com/stretchr/testify/mock",
 			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
 			"revisionTime": "2017-01-30T11:31:45Z"
 		},
@@ -75,6 +99,12 @@
 			"revisionTime": "2017-01-30T11:31:45Z"
 		},
 		{
+			"checksumSHA1": "Dp8TnT65nINpRF/PrxrgmnYLsyA=",
+			"path": "github.com/stretchr/testify/suite",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+        {
 			"checksumSHA1": "tQJiIYU7lIwPhpJjddDXiFkDsZ8=",
 			"path": "github.com/taskcluster/go-got",
 			"revision": "be30a15e825169a70a00fcea97f7f6a611145c1e",


### PR DESCRIPTION
@petemoore suggested this as a way to avoid unnecessary go-getting, since anything matched by the /... will be vendored, anyway.