### PR TITLE
Add cancellation by worker-type, and cancellation confirmation

### DIFF
--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -52,7 +52,7 @@ func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, 
 	}
 
 	// ask for confirmation before cancellation
-	if confirmCancellation(tasks, out) == false {
+	if !confirmCancellation(tasks, out) {
 		fmt.Fprintln(out, "Cancellation of tasks aborted.")
 		return nil
 	}

--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -11,6 +11,17 @@ import (
 	"golang.org/x/net/context"
 )
 
+func init() {
+	cancelCmd := &cobra.Command{
+		Use:   "cancel <taskGroupId>",
+		Short: "Cancel a whole group by taskGroupId.",
+		RunE:  executeHelperE(runCancel),
+	}
+	cancelCmd.Flags().StringP("worker-type", "w", "", "Only cancel tasks with a certain worker type.")
+
+	Command.AddCommand(cancelCmd)
+}
+
 // runCancel cancels all tasks of a group.
 //
 // It first fetches the list of all tasks associated with the given group,

--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -17,30 +17,44 @@ import (
 // then filters for only cancellable tasks (unscheduled, pending, running),
 // and finally runs all cancellations concurrently, because they are
 // independent of each other.
-func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, _ *pflag.FlagSet) error {
+func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, flags *pflag.FlagSet) error {
 	q := queue.New(credentials)
 	groupID := args[0]
 
 	// Because the list of tasks can be arbitrarily long, we have to loop until
 	// we are told not to.
 	tasks := make([]string, 0)
-	continuation := ""
+	cont := ""
+
 	for {
-		ts, err := q.ListTaskGroup(groupID, continuation, "")
+		// get next TaskGroup for groupID
+		ts, err := q.ListTaskGroup(groupID, cont, "")
 		if err != nil {
 			return fmt.Errorf("could not fetch tasks for group %s: %v", groupID, err)
 		}
 
+		// set tasks that meet the criteria (see filterTask) to be deleted
 		for _, t := range ts.Tasks {
-			if t.Status.State == "unscheduled" || t.Status.State == "pending" || t.Status.State == "running" {
+			if filterTask(t.Status, flags) {
 				tasks = append(tasks, t.Status.TaskID)
 			}
 		}
 
-		continuation = ts.ContinuationToken
-		if continuation == "" {
+		// break if there are no more tasks for that groupID
+		if cont = ts.ContinuationToken; cont == "" {
 			break
 		}
+	}
+
+	if len(tasks) == 0 {
+		fmt.Fprintln(out, "No suitable tasks found for cancellation.")
+		return nil
+	}
+
+	// ask for confirmation before cancellation
+	if confirmCancellation(tasks, out) == false {
+		fmt.Fprintln(out, "Cancellation of tasks aborted.")
+		return nil
 	}
 
 	// Here we use a waitgroup to ensure that we return once all the tasks have
@@ -101,5 +115,50 @@ func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, 
 		return fmt.Errorf("could not cancel all tasks: %v", <-errChan)
 	case <-regularExit:
 		return nil
+	}
+}
+
+// filterTask takes a task and returns whether or not this task should be
+// set for cancellation, based on the specified filters through flags
+func filterTask(status queue.TaskStatusStructure, flags *pflag.FlagSet) bool {
+	// first check - only delete tasks that are unscheduled, pending, running
+	if status.State != "unscheduled" && status.State != "pending" && status.State != "running" {
+		return false
+	}
+
+	// filter for worker type, if one specified
+	// if no worker type is specified, its value is "" so the condition is skipped
+	if workerType, _ := flags.GetString("worker-type"); workerType != "" {
+		if workerType != status.WorkerType {
+			return false
+		}
+	}
+
+	// TODO add other filters here when necessary
+
+	return true
+}
+
+// confirmCancellation lists the tasks to be cancelled and prompts to confirm cancellation
+func confirmCancellation(tasks []string, out io.Writer) bool {
+	// list tasks
+	fmt.Fprintf(out, "The following %d tasks will be cancelled:\n", len(tasks))
+
+	for _, task := range tasks {
+		fmt.Fprintf(out, "\tTask %s\n", task)
+	}
+
+	for {
+		fmt.Fprint(out, "Are you sure you want to cancel these tasks? [Y/n] ")
+
+		var c string
+		fmt.Scanf("%s", &c)
+
+		if c == "y" || c == "Y" {
+			return true
+		} else if c == "n" || c == "N" {
+			return false
+		}
+		// otherwise reloop to ask again
 	}
 }

--- a/cmds/group/group.go
+++ b/cmds/group/group.go
@@ -19,6 +19,7 @@ func init() {
 		Short: "Cancel a whole group by taskGroupId.",
 		RunE:  executeHelperE(runCancel),
 	}
+	cancelCmd.Flags().StringP("worker-type", "w", "", "Only delete tasks with a certain worker type.")
 	Command.AddCommand(cancelCmd)
 
 	root.Command.AddCommand(Command)

--- a/cmds/group/group.go
+++ b/cmds/group/group.go
@@ -14,13 +14,5 @@ var (
 )
 
 func init() {
-	cancelCmd := &cobra.Command{
-		Use:   "cancel <taskGroupId>",
-		Short: "Cancel a whole group by taskGroupId.",
-		RunE:  executeHelperE(runCancel),
-	}
-	cancelCmd.Flags().StringP("worker-type", "w", "", "Only delete tasks with a certain worker type.")
-	Command.AddCommand(cancelCmd)
-
 	root.Command.AddCommand(Command)
 }


### PR DESCRIPTION
This is to address issue #126. We might not want to merge it right now.

It builds, but I don't really know anything about TaskCluster itself, and I'm not sure how to go about testing this (even manually).

Otherwise, I've added code that enables to filter tasks to cancel with extra criteria (for now, only `worker-type` has been implemented) and code that asks for confirmation before cancelling tasks.

Let me know what you think.