### PR TITLE
Require version 1.8 for checks and builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.7.3
+go: 1.8
 install: go get -t ./...
 script:
     - make

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ platform, and run it!
 
 ## Development
 
+### Requirements
+
+We currently support Go versions starting at 1.8; the project may or may not
+build on earlier versions.
+
+Please note that the default repositories for popular Linux distributions (e.g.
+Ubuntu) do not carry that version of Go. We recommend you download the latest
+version of the language from [the official website](https://golang.org/dl/).
+
 ### Building
 
 Getting the source is as simple as running the following command in your shell.

--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -8,7 +9,6 @@ import (
 	"github.com/spf13/pflag"
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"golang.org/x/net/context"
 )
 
 // runCancel cancels all tasks of a group.


### PR DESCRIPTION
Following issue #130.

Let's not merge this right now, as I'm not exactly sure of all the steps required to make sure we've moved to Go 1.8. For now, I've only modified a couple files and updated the README.