### PR TITLE
Avoid `go get` in travis build

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,8 +21,9 @@ tasks:
         - /bin/bash
         - '-c'
         - >-
-          go get -t github.com/taskcluster/taskcluster-cli
+          mkdir -p  /go/src/github.com/taskcluster/taskcluster-cli
           && cd  /go/src/github.com/taskcluster/taskcluster-cli 
+          && git init
           && git fetch {{ event.head.repo.url }} {{ event.head.ref }} 
           && git checkout {{ event.head.sha }} 
           && make 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go: 1.8
-install: go get -t ./...
+install: make prep
 script:
-    - make
+    - make build
     - go test ./...


### PR DESCRIPTION
Running `go get` will pull in package dependencies that are not vendored, so if we avoid using `go get` in our travis builds, we'll be sure we've vendored all our build and test dependencies, since there is no chance for libraries to make it into the go path via another means.