### PR TITLE
allow PRs from public

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,4 +1,5 @@
 version: 0
+allowPullRequests: public
 metadata:
   name: "TaskCluster .taskcluster.yml file"
   description: "Tasks for taskcluster-cli"


### PR DESCRIPTION
This should allow people who are not repository collaborators to run tasks.  We saw this in #126 where @yasch007's PR wasn't tested in taskcluster.