### PR TITLE
Make lint checks actually pass, and easier to run

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,6 +14,42 @@ tasks:
           - pull_request.opened
           - pull_request.synchronize
           - pull_request.reopened
+          - push
+    payload:
+      maxRunTime: 3600
+      image: 'golang:1.8'
+      command:
+        - /bin/bash
+        - '-c'
+        - >-
+          mkdir -p  /go/src/github.com/taskcluster/taskcluster-cli
+          && cd  /go/src/github.com/taskcluster/taskcluster-cli
+          && git init
+          && git fetch {{ event.head.repo.url }} {{ event.head.ref }}
+          && git checkout {{ event.head.sha }}
+          && go get -u github.com/alecthomas/gometalinter
+          && gometalinter --install --force
+          && go install ./...
+          && gometalinter --vendor --disable-all --deadline 5m
+          --enable=gotype --enable=golint
+          --enable=deadcode --enable=staticcheck --enable=misspell
+          --enable=vet --enable=vetshadow --enable=gosimple
+          --skip=apis --skip=vendor ./...
+    metadata:
+      name: "TaskCluster GitHub Lint Checks"
+      description: "All non-integration tests"
+      owner: "{{ event.head.user.email }}"
+      source: "{{ event.head.repo.url }}"
+
+  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
+    workerType: "{{ taskcluster.docker.workerType }}"
+    extra:
+      github:
+        env: true
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
     payload:
       maxRunTime: 3600
       image: 'golang:1.8'
@@ -28,14 +64,6 @@ tasks:
           && git checkout {{ event.head.sha }}
           && make
           && go test -v -race ./...
-          && go get -u github.com/alecthomas/gometalinter
-          && gometalinter --install --force
-          && go install ./...
-          && gometalinter --vendor --disable-all --deadline 5m
-          --enable=gotype --enable=golint
-          --enable=deadcode --enable=staticcheck --enable=misspell
-          --enable=vet --enable=vetshadow --enable=gosimple
-          --skip=apis --skip=vendor ./...
       artifacts:
         public/taskcluster-linux:
           path: /go/src/github.com/taskcluster/taskcluster-cli/taskcluster
@@ -45,6 +73,7 @@ tasks:
       description: "All non-integration tests"
       owner: "{{ event.head.user.email }}"
       source: "{{ event.head.repo.url }}"
+
   - provisionerId: "{{ taskcluster.docker.provisionerId }}"
     workerType: "{{ taskcluster.docker.workerType }}"
     extra:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -31,7 +31,7 @@ tasks:
           && gometalinter --install --force
           && go install ./...
           && gometalinter --vendor --disable-all --deadline 5m
-          --enable=gotype --enable=golint
+          --enable=golint
           --enable=deadcode --enable=staticcheck --enable=misspell
           --enable=vet --enable=vetshadow --enable=gosimple
           --skip=apis --skip=vendor ./...

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -27,14 +27,7 @@ tasks:
           && git init
           && git fetch {{ event.head.repo.url }} {{ event.head.ref }}
           && git checkout {{ event.head.sha }}
-          && go get -u github.com/alecthomas/gometalinter
-          && gometalinter --install --force
-          && go install ./...
-          && gometalinter --vendor --disable-all --deadline 5m
-          --enable=golint
-          --enable=deadcode --enable=staticcheck --enable=misspell
-          --enable=vet --enable=vetshadow --enable=gosimple
-          --skip=apis --skip=vendor ./...
+          && make lint
     metadata:
       name: "TaskCluster GitHub Lint Checks"
       description: "All non-integration tests"
@@ -62,8 +55,7 @@ tasks:
           && git init
           && git fetch {{ event.head.repo.url }} {{ event.head.ref }}
           && git checkout {{ event.head.sha }}
-          && make
-          && go test -v -race ./...
+          && make test
       artifacts:
         public/taskcluster-linux:
           path: /go/src/github.com/taskcluster/taskcluster-cli/taskcluster

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,22 @@ clean:
 	rm -f ${BINARY}
 	rm -rf build
 
+test: prep build
+	go test -v -race ./...
+
+lint: prep
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install --force
+	go install ./...
+	gometalinter --vendor --disable-all --deadline 5m \
+		--enable=golint \
+		--enable=deadcode \
+		--enable=staticcheck \
+		--enable=misspell \
+		--enable=vet \
+		--enable=vetshadow \
+		--enable=gosimple \
+		--skip=apis --skip=vendor \
+		./...
+
 .PHONY: all prep build clean upload release

--- a/cmds/shell/cmd.go
+++ b/cmds/shell/cmd.go
@@ -82,7 +82,7 @@ func Execute(cmd *cobra.Command, args []string) error {
 
 	switch redirectURL.Query().Get("v") {
 	case "1":
-		return errors.New("The shell client doens't yet support v1 shells.")
+		return errors.New("the shell client doens't yet support v1 shells")
 	case "2":
 		sockURL, _ = url.Parse(redirectURL.Query().Get("socketUrl"))
 		shell, err = v2client.Dial(sockURL.String(), []string{"bash"}, tty)
@@ -90,7 +90,7 @@ func Execute(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("could not create the shell client: %v", err)
 		}
 	default:
-		return errors.New("Unknown shell version.")
+		return errors.New("unknown shell version")
 	}
 
 	// Switch terminal to raw mode


### PR DESCRIPTION
Just about every pull request since we have started running golint has has a big red X because golint found some lint problem in code the PR hadn't changed, but golint had not found that error in the last commit on master.  That means we're digging through logs to find out whether the red X is "real" or "fake", and we're tempted to ignore it.

I don't know why golint is doing this -- it's possible it's just under active development, and gometalinter is pulling in the latest, and that's adding new errors every few days.  At any rate, I think it's a net negative on development performance on this project.