### PR TITLE
Fix broken tests after adding cancellation confirmation

### DIFF
--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -19,6 +19,7 @@ func init() {
 		RunE:  executeHelperE(runCancel),
 	}
 	cancelCmd.Flags().StringP("worker-type", "w", "", "Only cancel tasks with a certain worker type.")
+	cancelCmd.Flags().BoolP("force", "f", false, "Skip cancellation confirmation.")
 
 	Command.AddCommand(cancelCmd)
 }
@@ -77,7 +78,7 @@ func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, 
 	}
 
 	// ask for confirmation before cancellation
-	if !confirmCancellation(tasks, tasksNames, out) {
+	if force, _ := flags.GetBool("force"); !force && !confirmCancellation(tasks, tasksNames, out) {
 		fmt.Fprintln(out, "Cancellation of tasks aborted.")
 		return nil
 	}

--- a/cmds/group/actors_test.go
+++ b/cmds/group/actors_test.go
@@ -102,6 +102,7 @@ func setUpCommand() (*bytes.Buffer, *cobra.Command) {
 	buf := &bytes.Buffer{}
 	cmd := &cobra.Command{}
 	cmd.SetOutput(buf)
+	cmd.Flags().Bool("force", true, "")
 
 	return buf, cmd
 }


### PR DESCRIPTION
The new confirmation feature broke the tests, since they didn't expect to have to send a confirmation through `stdin`.

Added a new `--force -f` flag to the `group cancel` subcommand to go around this problem.