### PR TITLE
Move config get back in config

### DIFF
--- a/cmds/config/get.go
+++ b/cmds/config/get.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/taskcluster/taskcluster-cli/cmds/root"
 )
 
 func init() {
@@ -17,7 +16,7 @@ func init() {
 	cmd.Flags().StringP("output", "o", "", "Write output to file [default: -]")
 	cmd.Flags().StringP("format", "f", "yaml", "Select output format [default: yaml]")
 
-	root.Command.AddCommand(cmd)
+	Command.AddCommand(cmd)
 }
 
 func cmdGet(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Seems like `config get` got put into the root instead of `config`. This fixes that :)