### PR TITLE
Add a task definition fetching command

### DIFF
--- a/cmds/task/fetchers.go
+++ b/cmds/task/fetchers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"encoding/json"
 
 	"github.com/spf13/pflag"
 	tcclient "github.com/taskcluster/taskcluster-client-go"
@@ -69,6 +70,25 @@ func runName(credentials *tcclient.Credentials, args []string, out io.Writer, _ 
 	}
 
 	fmt.Fprintln(out, t.Metadata.Name)
+	return nil
+}
+
+// runDef gets the definition of a given task.
+func runDef(credentials *tcclient.Credentials, args []string, out io.Writer, _ *pflag.FlagSet) error {
+	q := makeQueue(credentials)
+	taskID := args[0]
+
+	t, err := q.Task(taskID)
+	if err != nil {
+		return fmt.Errorf("could not get the task %s: %v", taskID, err)
+	}
+
+	def, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal task %s into json: %v", taskID, err)
+	}
+
+	fmt.Fprintln(out, string(def))
 	return nil
 }
 

--- a/cmds/task/fetchers_test.go
+++ b/cmds/task/fetchers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"encoding/json"
 
 	"github.com/spf13/cobra"
 	assert "github.com/stretchr/testify/require"
@@ -113,6 +114,21 @@ func (suite *FakeServerSuite) TestNameCommand() {
 	runName(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
 	suite.Equal(string(buf.Bytes()), "my-test\n")
+}
+
+func (suite *FakeServerSuite) TestDefCommand() {
+	// set up to run a command and capture output
+	buf, cmd := setUpCommand()
+
+	// run the command
+	args := []string{fakeTaskID}
+	runDef(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
+
+	var f interface{}
+	json.Unmarshal(buf.Bytes(), &f)
+	m := f.(map[string]interface{})
+	m = m["metadata"].(map[string]interface{})
+	suite.Equal(m["name"], "my-test")
 }
 
 // Test the `task log` subcommand against a real task, since it does its own

--- a/cmds/task/task.go
+++ b/cmds/task/task.go
@@ -40,6 +40,12 @@ func init() {
 			Short: "Get the name of a task.",
 			RunE:  executeHelperE(runName),
 		},
+		// definition
+		&cobra.Command{
+			Use:   "def <taskId>",
+			Short: "Get the full definition of a task.",
+			RunE:  executeHelperE(runDef),
+		},
 		// group
 		&cobra.Command{
 			Use:   "group <taskId>",


### PR DESCRIPTION
Forgive me for whatever golang sins I've committed. I want to have this for doing things like fetching the tasks from [this list](https://pastebin.mozilla.org/9031069) and passing the results to `jq` and friends.