### PR TITLE
Print status to stderr. r=dustin

### DIFF
--- a/cmds/status/status.go
+++ b/cmds/status/status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -25,6 +26,9 @@ var (
 	validArgs         []string
 	cache             = Cache()
 	pingURLsCachePath = filepath.Join("cmds", "status", "pingURLs.json")
+	magenta           = color.New(color.FgMagenta)
+	yellow            = color.New(color.FgYellow)
+	green             = color.New(color.FgGreen)
 )
 
 type (
@@ -154,7 +158,7 @@ func ReadCachedURLsFile(cache *configdir.Config, cachePath string) (cachedURLs *
 // already, and creating parent folders, if required), using the current time
 // for the retrieval timestamp.
 func (p PingURLs) Cache(cache *configdir.Config, cachePath string) (cachedURLs *CachedURLs, err error) {
-	color.Magenta("Writing cache file %v", filepath.Join(cache.Path, cachePath))
+	magenta.Fprintf(os.Stderr, "Writing cache file %v\n", filepath.Join(cache.Path, cachePath))
 
 	cachedURLs = &CachedURLs{
 		LastUpdated: time.Now(),
@@ -182,7 +186,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 // ScrapePingURLs queries manifestURL to return a manifest of services, which
 // are then queried to fetch ping URLs for taskcluster services
 func ScrapePingURLs(manifestURL string) (pingURLs PingURLs, err error) {
-	color.Yellow("Scraping ping URLs from %v", manifestURL)
+	yellow.Fprintf(os.Stderr, "Scraping ping URLs from %v\n", manifestURL)
 	var allAPIs map[string]string
 	err = objectFromJSONURL(manifestURL, &allAPIs)
 	if err != nil {
@@ -256,8 +260,8 @@ func respbody(service string) error {
 	}
 	if servstat.Alive {
 		living := "Alive"
-		fmt.Printf("      %v\n", service)
-		color.Green("      %v\n", living)
+		fmt.Fprintf(os.Stderr, "      %v\n", service)
+		green.Fprintf(os.Stderr, "      %v\n", living)
 	}
 
 	return nil

--- a/cmds/task/actors.go
+++ b/cmds/task/actors.go
@@ -3,6 +3,7 @@ package task
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/pflag"
 	tcclient "github.com/taskcluster/taskcluster-client-go"
@@ -16,7 +17,7 @@ func runCancel(credentials *tcclient.Credentials, args []string, out io.Writer, 
 
 	c, err := q.CancelTask(taskID)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("could not cancel the task %s: %v", taskID, err)
 	}
 


### PR DESCRIPTION
Within the "Do one job, and do it well" Unix philosophy, it is common to
glue commands together through shell pipes to achieve the desired
result. This implies commands must only print to stdout the result of
the processing of the program input, and any statuses or side effects
should go to stderr.

For taskcluster-cli, one example is the "api" subcommand, that wraps up
the taskcluster API and often prints a JSON string as the result of an
endpoint call. If we print other statuses to stdout, the JSON string
just becomes invalid and we cannot pipeline it to tools like jq [1].

[1] https://stedolan.github.io/jq/