### PR TITLE
Add support for bash completion file production

### DIFF
--- a/cmds/completions/completions.go
+++ b/cmds/completions/completions.go
@@ -1,0 +1,31 @@
+package completions
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/taskcluster/taskcluster-cli/cmds/root"
+)
+
+var (
+	defaultFilename = "bash_completion.sh"
+)
+
+func init() {
+	// Add the task subtree to the root.
+	use := "completions <filename (default:" + defaultFilename + ")>"
+	completionsCommand := &cobra.Command{
+		Short: "Provides bash completion script.",
+		RunE:  genCompletion,
+		Use:   use,
+	}
+	root.Command.AddCommand(completionsCommand)
+}
+
+func genCompletion(cmd *cobra.Command, args []string) error {
+	filename := defaultFilename
+	if len(args) != 0 {
+		filename = args[0]
+	}
+
+	root.Command.GenBashCompletionFile(filename)
+	return nil
+}

--- a/cmds/completions/completions.go
+++ b/cmds/completions/completions.go
@@ -14,8 +14,15 @@ func init() {
 	use := "completions <filename (default:" + defaultFilename + ")>"
 	completionsCommand := &cobra.Command{
 		Short: "Provides bash completion script.",
-		RunE:  genCompletion,
-		Use:   use,
+		Long: `Writes a bash completion script to the path specified, or the default filename if not given.
+
+To use, do one of the following:
+'source bash_completion.sh' to add to your current shell,
+Add 'source bash_completion.sh' to your bash login scripts
+On Linux you can also copy it to /etc/bash_completion.d/ so that future bash shells have it active.
+        `,
+		RunE: genCompletion,
+		Use:  use,
 	}
 	root.Command.AddCommand(completionsCommand)
 }

--- a/subtree_imports.go
+++ b/subtree_imports.go
@@ -4,6 +4,7 @@ package main
 // alphabetical order.
 
 import _ "github.com/taskcluster/taskcluster-cli/apis"
+import _ "github.com/taskcluster/taskcluster-cli/cmds/completions"
 import _ "github.com/taskcluster/taskcluster-cli/cmds/config"
 import _ "github.com/taskcluster/taskcluster-cli/cmds/from-now"
 import _ "github.com/taskcluster/taskcluster-cli/cmds/group"


### PR DESCRIPTION
Use cobra's own tools for generating the shell script.

    ./taskcluster completions
    source bash_completion.sh

Or:

    ./taskcluster completions mycompletion.sh
    source mycompletion.sh

or moving the file into `/etc/bash_completion.d` on Linux and resetting the shell.