### PR TITLE
taskcluster status panics when the status is not 200

### DIFF
--- a/cmds/status/status_test.go
+++ b/cmds/status/status_test.go
@@ -1,0 +1,61 @@
+package status
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type FakeServerSuite struct {
+	suite.Suite
+	testServer *httptest.Server
+}
+
+func (suite *FakeServerSuite) SetupSuite() {
+	// set up a fake server that knows how to answer the `task()` method
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/ping/alive", validAlivePingHandler)
+	handler.HandleFunc("/v1/ping/dead", validDeadPingHandler)
+	handler.HandleFunc("/v1/ping/invalid", invalidPingHandler)
+
+	suite.testServer = httptest.NewServer(handler)
+}
+
+func validAlivePingHandler(w http.ResponseWriter, _ *http.Request) {
+	io.WriteString(w, `{ "alive": true, "uptime": 13958.262}`)
+}
+
+func validDeadPingHandler(w http.ResponseWriter, _ *http.Request) {
+	io.WriteString(w, `{ "alive": false, "uptime": 13958.262}`)
+}
+
+func invalidPingHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusServiceUnavailable)
+}
+
+func TestFakeServerSuite(t *testing.T) {
+	suite.Run(t, new(FakeServerSuite))
+}
+
+func (suite *FakeServerSuite) TestObjectFromJSONURL() {
+	var servstat PingResponse
+	var err error
+	url := suite.testServer.URL
+
+	// valid alive
+	err = objectFromJSONURL(url+"/v1/ping/alive", &servstat)
+	suite.NoError(err, "The first ping should be valid")
+	suite.True(servstat.Alive, "The first ping should be alive")
+
+	// valid alive
+	err = objectFromJSONURL(url+"/v1/ping/dead", &servstat)
+	suite.NoError(err, "The second ping should be valid")
+	suite.False(servstat.Alive, "The second ping should be dead")
+
+	// invalid
+	err = objectFromJSONURL(url+"/v1/ping/invalid", &servstat)
+	suite.EqualError(err, "Bad (!= 200) status code 503 from "+url+"/v1/ping/invalid", "The third ping should be invalid")
+}


### PR DESCRIPTION
Running taskcluster status when a service doesn't return 200 panics the whole cli.

```bash
$ taskcluster status
      aws-provisioner
      Alive
      hooks
      Alive
      index
      Alive
      login
      Alive
panic: Bad (!= 200) status code 503 from https://pulse.taskcluster.net/v1/ping

goroutine 1 [running]:
github.com/taskcluster/taskcluster-cli/cmds/status.status(0xc4204adb00, 0xce0c90, 0xb, 0x0, 0x0, 0x0)
	/home/xav0989/Workspace/go/src/github.com/taskcluster/taskcluster-cli/cmds/status/status.go:277 +0xcd
github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra.(*Command).execute(0xc4204adb00, 0xce0c90, 0x0, 0x0, 0xc4204adb00, 0xce0c90)
	/home/xav0989/Workspace/go/src/github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra/command.go:644 +0x3f2
github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xcbe860, 0x0, 0x0, 0x0)
	/home/xav0989/Workspace/go/src/github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra/command.go:734 +0x339
github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra.(*Command).Execute(0xcbe860, 0xc4200001a0, 0xc4200001a0)
	/home/xav0989/Workspace/go/src/github.com/taskcluster/taskcluster-cli/vendor/github.com/spf13/cobra/command.go:693 +0x2b
main.main()
	/home/xav0989/Workspace/go/src/github.com/taskcluster/taskcluster-cli/main.go:15 +0x32
```