### PR TITLE
Add two group subcommands for group status

### DIFF
--- a/cmds/group/actors.go
+++ b/cmds/group/actors.go
@@ -3,7 +3,9 @@ package group
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -11,6 +13,8 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
 )
+
+var listFormat string
 
 func init() {
 	cancelCmd := &cobra.Command{
@@ -22,6 +26,32 @@ func init() {
 	cancelCmd.Flags().BoolP("force", "f", false, "Skip cancellation confirmation.")
 
 	Command.AddCommand(cancelCmd)
+
+	statusCmd := &cobra.Command{
+		Use:   "status <taskGroupId>",
+		Short: "Show the status of a task group",
+		RunE:  executeHelperE(runStatus),
+	}
+
+	Command.AddCommand(statusCmd)
+
+	listCmd := &cobra.Command{
+		Use:   "list <taskGroupId>",
+		Short: "List task details: ID and label",
+		RunE:  executeHelperE(runList),
+	}
+	listCmd.Flags().BoolP("all", "a", false, "Include all tasks (Overrides other options).")
+
+	listCmd.Flags().BoolP("running", "r", false, "Include running tasks.")
+	listCmd.Flags().BoolP("failed", "f", false, "Include failed tasks.")
+	listCmd.Flags().BoolP("exception", "e", false, "Include exception tasks.")
+	listCmd.Flags().BoolP("complete", "c", false, "Include complete tasks.")
+	listCmd.Flags().BoolP("unscheduled", "u", false, "Include unscheduled tasks.")
+	listCmd.Flags().BoolP("pending", "p", false, "Include pending tasks.")
+
+	listCmd.Flags().StringVar(&listFormat, "format-string", "{{ .Status.TaskID }} {{ .Task.Metadata.Name }} {{ .Status.State }}", "Go Template string for output")
+
+	Command.AddCommand(listCmd)
 }
 
 var queueBaseURL string
@@ -187,4 +217,85 @@ func confirmCancellation(ids []string, names []string, out io.Writer) bool {
 		}
 		// otherwise reloop to ask again
 	}
+}
+
+// runStatus displays the status summary of tasks in a group.
+//
+// It first fetches the list of all tasks associated with the given group,
+// then counts the unique states of the final run of each task
+func runStatus(credentials *tcclient.Credentials, args []string, out io.Writer, flags *pflag.FlagSet) error {
+	q := makeQueue(credentials)
+	groupID := args[0]
+
+	counter := make(map[string]int)
+
+	cont := ""
+
+	for {
+		// get next TaskGroup for groupID
+		ts, err := q.ListTaskGroup(groupID, cont, "")
+		if err != nil {
+			return fmt.Errorf("could not fetch tasks for group %s: %v", groupID, err)
+		}
+
+		for _, t := range ts.Tasks {
+			counter[t.Status.State]++
+		}
+
+		// break if there are no more tasks for that groupID
+		if cont = ts.ContinuationToken; cont == "" {
+			break
+		}
+	}
+
+	for status, count := range counter {
+		fmt.Fprintf(out, "%s: %d\n", status, count)
+	}
+
+	return nil
+}
+
+// runList displays the a list of task IDs and labels that match the given statuses
+//
+// It first fetches the list of all tasks associated with the given group
+func runList(credentials *tcclient.Credentials, args []string, out io.Writer, flags *pflag.FlagSet) error {
+	q := makeQueue(credentials)
+	groupID := args[0]
+
+	cont := ""
+
+	templ := template.Must(template.New("listFormat").Parse(strings.Join([]string{listFormat, "\n"}, "")))
+
+	for {
+		// get next TaskGroup for groupID
+		ts, err := q.ListTaskGroup(groupID, cont, "")
+		if err != nil {
+			return fmt.Errorf("could not fetch tasks for group %s: %v", groupID, err)
+		}
+
+		for _, t := range ts.Tasks {
+			if filterListTask(t.Status, flags) {
+				templ.Execute(out, t)
+			}
+		}
+
+		// break if there are no more tasks for that groupID
+		if cont = ts.ContinuationToken; cont == "" {
+			break
+		}
+	}
+
+	return nil
+}
+
+// filterListTask takes a task and returns whether or not this task should be
+// included in the list requested by the user
+func filterListTask(status queue.TaskStatusStructure, flags *pflag.FlagSet) bool {
+	if include, err := flags.GetBool("all"); include && err == nil {
+		return true
+	}
+	if include, err := flags.GetBool(status.State); include && err == nil {
+		return true
+	}
+	return false
 }

--- a/cmds/group/actors_test.go
+++ b/cmds/group/actors_test.go
@@ -121,7 +121,7 @@ func (suite *FakeServerSuite) TestRunCancel() {
 	args := []string{fakeGroupID}
 	runCancel(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("cancelling task ANnmjMocTymeTID0tlNJAw\n", string(buf.Bytes()))
+	suite.Equal("cancelling task ANnmjMocTymeTID0tlNJAw\n", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunStatus() {
@@ -141,7 +141,7 @@ func (suite *FakeServerSuite) TestRunStatusBadGroupId() {
 	args := []string{badGroupID}
 	runStatus(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("", string(buf.Bytes()))
+	suite.Equal("", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunListAll() {
@@ -153,7 +153,7 @@ func (suite *FakeServerSuite) TestRunListAll() {
 	args := []string{fakeGroupID}
 	runList(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("ANnmjMocTymeTID0tlNJAw test-framework-task/opt pending\n", string(buf.Bytes()))
+	suite.Equal("ANnmjMocTymeTID0tlNJAw test-framework-task/opt pending\n", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunListPending() {
@@ -165,7 +165,7 @@ func (suite *FakeServerSuite) TestRunListPending() {
 	args := []string{fakeGroupID}
 	runList(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("ANnmjMocTymeTID0tlNJAw test-framework-task/opt pending\n", string(buf.Bytes()))
+	suite.Equal("ANnmjMocTymeTID0tlNJAw test-framework-task/opt pending\n", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunListWrongFilter() {
@@ -177,7 +177,7 @@ func (suite *FakeServerSuite) TestRunListWrongFilter() {
 	args := []string{fakeGroupID}
 	runList(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("", string(buf.Bytes()))
+	suite.Equal("", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunListBadGraphId() {
@@ -189,5 +189,5 @@ func (suite *FakeServerSuite) TestRunListBadGraphId() {
 	args := []string{badGroupID}
 	runList(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("", string(buf.Bytes()))
+	suite.Equal("", buf.String())
 }

--- a/cmds/group/actors_test.go
+++ b/cmds/group/actors_test.go
@@ -131,7 +131,7 @@ func (suite *FakeServerSuite) TestRunStatus() {
 	args := []string{fakeGroupID}
 	runStatus(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags())
 
-	suite.Equal("pending: 1\n", string(buf.Bytes()))
+	suite.Equal("pending: 1\n", buf.String())
 }
 
 func (suite *FakeServerSuite) TestRunStatusBadGroupId() {


### PR DESCRIPTION
Two group subcommands that will prove useful for releng

$ taskcluster group status eShtp2faQgy4iZZOIhXvhw
failed: 43
unscheduled: 17
completed: 4906

$ taskcluster group list eShtp2faQgy4iZZOIhXvhw --unscheduled
C2iD74hYRYODZzoE3cDqqw checksums-signing-tr-linux64-nightly/opt unscheduled
C73U9ZPOT4mGJdVAHa48Zw beetmover-repackage-tr-linux64-nightly/opt unscheduled
...

The latter takes other options such as '--all' for all states, or allows
multiple of pending, complete, unscheduled, failed, exception, running to catch
all the states. The output format can be controlled with a Go Template string,
passed as --format-string, if the default is not satisfactory.