### PR TITLE
Bug 1194767 - Use "nice" slugs for taskIds

### DIFF
--- a/apis/codegen_test.go
+++ b/apis/codegen_test.go
@@ -24,7 +24,7 @@ func TestCodeGeneration(t *testing.T) {
 	defer codegenServer.Close()
 
 	// query server, generate code
-	source, err := GenerateServices(codegenServer.URL + "/manifest.json", "servicesTest", "schemasTest")
+	source, err := GenerateServices(codegenServer.URL+"/manifest.json", "servicesTest", "schemasTest")
 	assert.NoError(err, fmt.Sprintf("failed generating services: %s", err))
 
 	// check that the returned byte thing is correct

--- a/cmds/task/actors.go
+++ b/cmds/task/actors.go
@@ -63,7 +63,7 @@ func runRetrigger(credentials *tcclient.Credentials, args []string, out io.Write
 
 	exactRetrigger, _ := flagSet.GetBool("exact")
 
-	newTaskID := slugid.V4()
+	newTaskID := slugid.Nice()
 	now := time.Now().UTC()
 
 	origCreated, err := time.Parse(time.RFC3339, t.Created.String())
@@ -85,10 +85,10 @@ func runRetrigger(credentials *tcclient.Credentials, args []string, out io.Write
 	// TaskDefinitionResponse: https://github.com/taskcluster/taskcluster-client-go/blob/88cfe471bfe2eb8fc9bc22d9cde6a65e74a9f3e5/tcqueue/types.go#L1554-L1716
 
 	newDependencies := []string{}
-	newRoutes       := []string{}
+	newRoutes := []string{}
 	if exactRetrigger {
 		newDependencies = t.Dependencies
-		newRoutes       = t.Routes
+		newRoutes = t.Routes
 	}
 
 	newT := &queue.TaskDefinitionRequest{

--- a/cmds/task/fetchers.go
+++ b/cmds/task/fetchers.go
@@ -3,10 +3,10 @@ package task
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"encoding/json"
 
 	"github.com/spf13/pflag"
 	tcclient "github.com/taskcluster/taskcluster-client-go"

--- a/cmds/task/run.go
+++ b/cmds/task/run.go
@@ -84,7 +84,7 @@ func runRunTask(cmd *cobra.Command, args []string) error {
 	}
 
 	// Generate a new taskID
-	taskID := slugid.V4()
+	taskID := slugid.Nice()
 	runPayload.TaskGroupID = taskID
 
 	// Build the environment variables.

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/taskcluster/taskcluster-cli/config"
 	"github.com/taskcluster/taskcluster-cli/cmds/root"
+	"github.com/taskcluster/taskcluster-cli/config"
 )
 
 func main() {


### PR DESCRIPTION
At the same time, I formatted the source using `go fmt`.

See [bug 1194767](https://bugzilla.mozilla.org/show_bug.cgi?id=1194767) for context.

Also see taskcluster/generic-worker#96.