### PR TITLE
Bug 1444458 - Expire cached ping URLs after 365 days rather than one day

### DIFF
--- a/cmds/status/status.go
+++ b/cmds/status/status.go
@@ -126,7 +126,7 @@ func NewPingURLs() (pingURLs PingURLs, err error) {
 	if err != nil {
 		return
 	}
-	if cachedURLs.Expired(time.Hour * 24) {
+	if cachedURLs.Expired(time.Hour * 24 * 365) {
 		return RefreshCache(manifestURL, cache, pingURLsCachePath)
 	}
 	pingURLs = cachedURLs.PingURLs


### PR DESCRIPTION
@djmitche 
While we wait for a complete solution to [bug 1444458](https://bugzil.la/1444458), this is a partial solution so the ping urls cache only expires after 365 days, rather than after one day.