### PR TITLE
config: Fail if ClientID not provided

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -45,4 +45,8 @@ func Setup() {
 			AuthorizedScopes: authorizedScopes,
 		}
 	}
+	if ok1 || ok2 {
+		fmt.Println("Either ClientID or Access Token not set")
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster-cli/issues/191