### PR TITLE
Fix a bug that won't let AccessToken and ClientID generate

### DIFF
--- a/config/init.go
+++ b/config/init.go
@@ -45,7 +45,7 @@ func Setup() {
 			AuthorizedScopes: authorizedScopes,
 		}
 	}
-	if ok1 || ok2 {
+	if ok1 != ok2 {
 		fmt.Fprintln(os.Stderr, "Either ClientID or Access Token not set")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Tried to ./taskcluster signin . After some time browser won't open to generate ClientID and AccessToken and fails into "Either ClientID or Access Token not set" all over again. Have been talking with :tomprince about that, assisted me and corrected that into my local version and it works.