### PR TITLE
Add `wait-for <taskId>` command

### DIFF
--- a/cmds/pulse/inspect_pulse.go
+++ b/cmds/pulse/inspect_pulse.go
@@ -40,23 +40,22 @@ func inspectPulse(cmd *cobra.Command, args []string) error {
 			args[0],
 			args[1]}}
 
-	json_bindings, _ := json.Marshal(Bindings{Bindings: bindings})
-	values := url.Values{"bindings": {string(json_bindings)}}
-	eventsUrl := "https://events.taskcluster.net/v1/connect/?" + values.Encode()
+	jsonBindings, _ := json.Marshal(Bindings{Bindings: bindings})
+	values := url.Values{"bindings": {string(jsonBindings)}}
+	eventsURL := "https://events.taskcluster.net/v1/connect/?" + values.Encode()
 
-	stream, err := eventsource.Subscribe(eventsUrl, "")
+	stream, err := eventsource.Subscribe(eventsURL, "")
 	if err != nil {
 		return fmt.Errorf("Error getting request: %v", err)
 	}
 
 	for {
 		event, ok := <-stream.Events
-		if ok == false {
+		if !ok {
 			err := <-stream.Errors
 			stream.Close()
 			return fmt.Errorf("Error: %v", err)
 		}
 		fmt.Println(event.Event(), event.Data())
 	}
-	return nil
 }

--- a/cmds/pulse/wait-for.go
+++ b/cmds/pulse/wait-for.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/taskcluster/taskcluster-cli/cmds/root"
-	"github.com/taskcluster/taskcluster-client-go/tcqueue"
+	"github.com/taskcluster/taskcluster-client-go/queue"
 
 	"github.com/spf13/cobra"
 
@@ -57,18 +57,18 @@ func waitForTask(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting request: %v", err)
 	}
-	queue := tcqueue.New(nil)
+	q := queue.New(nil)
 	var pulseMessage map[string]interface{}
 
 	for {
 		event, ok := <-stream.Events
-		if ok == false {
+		if !ok {
 			err := <-stream.Errors
 			stream.Close()
 			return fmt.Errorf("Error: %v", err)
 		}
 		if event.Event() == "ready" {
-			status, err := queue.Status(args[0])
+			status, err := q.Status(args[0])
 			if err != nil {
 				return fmt.Errorf("Error: %v", err)
 			}

--- a/cmds/pulse/wait-for.go
+++ b/cmds/pulse/wait-for.go
@@ -3,11 +3,11 @@ package pulse
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/taskcluster/taskcluster-cli/cmds/root"
+	"github.com/taskcluster/taskcluster-client-go/tcqueue"
 
 	"github.com/spf13/cobra"
 
@@ -24,7 +24,7 @@ func init() {
 
 func waitForTask(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return errors.New("%s expects argument <taskId>", cmd.Name())
+		return fmt.Errorf("%s expects argument <taskId>", cmd.Name())
 	}
 
 	type Binding struct {
@@ -36,19 +36,29 @@ func waitForTask(cmd *cobra.Command, args []string) error {
 		Bindings []Binding `json:"bindings"`
 	}
 
+	routingKeyPattern := fmt.Sprintf("primary.%s.#", args[0])
 	bindings := []Binding{
 		Binding{
-			args[0],
-			args[1]}}
+			"exchange/taskcluster-queue/v1/task-completed",
+			routingKeyPattern},
+		Binding{
+			"exchange/taskcluster-queue/v1/task-failed",
+			routingKeyPattern},
+		Binding{
+			"exchange/taskcluster-queue/v1/task-exception",
+			routingKeyPattern},
+	}
 
-	json_bindings, _ := json.Marshal(Bindings{Bindings: bindings})
-	values := url.Values{"bindings": {string(json_bindings)}}
-	eventsUrl := "https://taskcluster-events-staging.herokuapp.com/v1/connect/?" + values.Encode()
+	jsonBindings, _ := json.Marshal(Bindings{Bindings: bindings})
+	values := url.Values{"bindings": {string(jsonBindings)}}
+	eventsURL := "https://events.taskcluster.net/v1/connect/?" + values.Encode()
 
-	stream, err := eventsource.Subscribe(eventsUrl, "")
+	stream, err := eventsource.Subscribe(eventsURL, "")
 	if err != nil {
 		return fmt.Errorf("Error getting request: %v", err)
 	}
+	queue := tcqueue.New(nil)
+	var pulseMessage map[string]interface{}
 
 	for {
 		event, ok := <-stream.Events
@@ -57,7 +67,21 @@ func waitForTask(cmd *cobra.Command, args []string) error {
 			stream.Close()
 			return fmt.Errorf("Error: %v", err)
 		}
-		fmt.Println(event.Event(), event.Data())
+		if event.Event() == "ready" {
+			status, err := queue.Status(args[0])
+			if err != nil {
+				return fmt.Errorf("Error: %v", err)
+			}
+			state := status.Status.State
+			if state == "completed" || state == "failed" || state == "exception" {
+				fmt.Println(status.Status)
+				return nil
+			}
+		}
+		if event.Event() == "message" {
+			json.Unmarshal([]byte(event.Data()), &pulseMessage)
+			fmt.Println(pulseMessage["payload"])
+			return nil
+		}
 	}
-	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,6 +39,12 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
+			"checksumSHA1": "MT58r0hh82Igj2em/QMUNPPW708=",
+			"path": "github.com/donovanhide/eventsource",
+			"revision": "3ed64d21fb0b6bd8b49bcfec08f3004daee8723d",
+			"revisionTime": "2017-10-31T11:33:27Z"
+		},
+		{
 			"checksumSHA1": "kR64D1QzAOSM9LHOnTPdbigC8q0=",
 			"path": "github.com/fatih/camelcase",
 			"revision": "f6a740d52f961c60348ebb109adde9f4635d7540",


### PR DESCRIPTION
`./taskcluster wait-for <taskId>` finishes when the task is resolved( changes state to  `completed` , `failed` or `exception`)
It connects to the events server, and waits for messages. We call `status(taskId)` before continuing in case the task resolved before we could set up connection.