### PR TITLE
Do not expire release binaries artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -137,6 +137,7 @@ tasks:
       taskId: {$eval: as_slugid("release_task")}
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
+      expires: {$fromNow: '100 years'}
       scopes:
         - auth:aws-s3:read-write:downloads-taskcluster-net/taskcluster-cli/
       routes:


### PR DESCRIPTION
Links under https://github.com/taskcluster/taskcluster-cli#installation are currently 404, presumably because it’s been more than a year (the default task expiry) since the last release.